### PR TITLE
chore: dual-target web/desktop build setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env.local and fill in real values. Vite exposes any var prefixed
+# VITE_* to client code. .env.local is gitignored.
+
+# Cesium Ion access token — https://ion.cesium.com/tokens
+# Optional. Without a token the globe falls back to Bing imagery via Cesium's
+# default ephemeral key (rate-limited). Required for production web builds.
+VITE_CESIUM_TOKEN=
+
+# Google Analytics 4 measurement ID (e.g. G-XXXXXXXXXX). Web build only.
+# When set, GA4 + Consent Mode v2 wires up at runtime. Empty → no analytics.
+VITE_GA_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ release/
 .claude/
 *.tmp.*
 debug_bbl*.mjs
+.env
+.env.local
+.env.*.local

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EdgeTX Log Parser
 
-A desktop flight log visualiser for EdgeTX RC aircraft. Load a CSV log from your transmitter's SD card and replay the entire flight in 3D — satellite map, live attitude, synced charts.
+A flight log visualiser for EdgeTX RC aircraft. Load a CSV log from your transmitter's SD card and replay the entire flight in 3D — satellite map, live attitude, synced charts.
 
 [![EdgeTX Log Parser — video walkthrough](https://img.youtube.com/vi/6MLQCoG5t2w/maxresdefault.jpg)](https://youtu.be/6MLQCoG5t2w)
 
@@ -8,9 +8,19 @@ A desktop flight log visualiser for EdgeTX RC aircraft. Load a CSV log from your
 
 ---
 
-## Downloads
+## Two ways to use it
 
-Grab the latest build from [**Releases**](https://github.com/narenana/edgetx-log-parser/releases):
+**🌐 Web app** — open in any modern browser, drop a log, done. Logs never leave your machine; parsing and rendering all happen client-side. Best for one-off viewing or sharing a quick look on someone else's computer.
+
+**💻 Desktop app (Windows)** — installer / portable build with the full Electron shell. Same UI, file-association support, and works offline. Best for regular use.
+
+### Web
+
+Visit the hosted version *(domain coming soon)*. No install, no upload — your CSV is parsed in-browser with PapaParse, drawn with Cesium / Three.js / Leaflet, and discarded when you close the tab.
+
+### Desktop downloads
+
+Grab the latest Windows build from [**Releases**](https://github.com/narenana/edgetx-log-parser/releases):
 
 | File | Description |
 |------|-------------|
@@ -147,15 +157,28 @@ git clone https://github.com/narenana/edgetx-log-parser.git
 cd edgetx-log-parser
 npm install
 
-# Start dev server + Electron with hot reload
-npm run dev
-
-# Production build (Vite)
-npm run build
-
-# Package Windows installer + portable exe
-npm run dist
+# Optional: copy .env.example to .env.local and fill in tokens
+cp .env.example .env.local
 ```
+
+The codebase builds two targets from one source. `VITE_BUILD_TARGET` (set via `cross-env` in the npm scripts) is exposed at runtime as `import.meta.env.VITE_BUILD_TARGET` so web-only features (analytics, install prompts) can be gated cleanly.
+
+```bash
+# ── Web target (browser, hosted on Cloudflare Pages) ─────────────────────
+npm run dev:web        # Vite dev server only — http://localhost:5173
+npm run build          # cross-env VITE_BUILD_TARGET=web vite build
+
+# ── Desktop target (Electron) ────────────────────────────────────────────
+npm run dev            # Vite + Electron with hot reload
+npm run build:desktop  # cross-env VITE_BUILD_TARGET=desktop vite build
+npm run dist           # build:desktop + electron-builder (NSIS + portable)
+```
+
+Both targets share `base: './'`, so the same `dist/` works for `file://` (Electron) and for path-prefix hosting (a Cloudflare Worker on the customer site strips `/log-viewer/` and forwards to Pages).
+
+**Env vars** — `.env.example` lists them. All `VITE_*` vars are inlined into the client bundle at build time:
+- `VITE_CESIUM_TOKEN` — Cesium Ion access token (optional; falls back to ephemeral key)
+- `VITE_GA_ID` — GA4 measurement ID (web build only; empty disables analytics)
 
 **Stack:** Electron 31 · Vite 5 · React 18 · CesiumJS · Three.js · Leaflet · Chart.js · PapaParse
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edgetx-log-parser",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edgetx-log-parser",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "cesium": "^1.140.0",
         "chart.js": "^4.4.2",
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
         "concurrently": "^8.2.2",
+        "cross-env": "^7.0.3",
         "electron": "^31.0.0",
         "electron-builder": "^24.13.3",
         "electron-reload": "^2.0.0-alpha.1",
@@ -3143,6 +3144,25 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "author": "narenana",
   "scripts": {
     "dev": "concurrently -k \"vite\" \"wait-on tcp:5173 && electron .\"",
-    "build": "vite build",
+    "dev:web": "vite",
+    "build": "cross-env VITE_BUILD_TARGET=web vite build",
+    "build:desktop": "cross-env VITE_BUILD_TARGET=desktop vite build",
     "preview": "vite preview",
-    "dist": "npm run build && electron-builder"
+    "dist": "npm run build:desktop && electron-builder"
   },
   "build": {
     "appId": "com.narenana.edgetx-log-parser",
@@ -23,19 +25,40 @@
     ],
     "win": {
       "target": [
-        { "target": "nsis", "arch": ["x64"] },
-        { "target": "portable", "arch": ["x64"] }
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
       ]
     },
     "linux": {
       "target": [
-        { "target": "tar.gz", "arch": ["x64"] }
+        {
+          "target": "tar.gz",
+          "arch": [
+            "x64"
+          ]
+        }
       ],
       "category": "Utility"
     },
     "mac": {
       "target": [
-        { "target": "zip", "arch": ["x64", "arm64"] }
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "category": "public.app-category.utilities",
       "identity": null
@@ -60,6 +83,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "electron": "^31.0.0",
     "electron-builder": "^24.13.3",
     "electron-reload": "^2.0.0-alpha.1",

--- a/src/components/GlobeView.jsx
+++ b/src/components/GlobeView.jsx
@@ -4,7 +4,9 @@ import * as THREE from 'three'
 import 'cesium/Build/Cesium/Widgets/widgets.css'
 import { interpRows } from '../utils/interpRows'
 
-Cesium.Ion.defaultAccessToken = ''
+// Cesium Ion token comes from Vite env (VITE_CESIUM_TOKEN). Empty token still
+// renders Bing-imagery fallback; a real token unlocks higher-res tiles + 3D Tiles.
+Cesium.Ion.defaultAccessToken = import.meta.env.VITE_CESIUM_TOKEN || ''
 
 const FM_COLORS = {
   ANGL: '#9ece6a', RTH: '#f7768e', CRUZ: '#7dcfff',

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,20 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import cesium from 'vite-plugin-cesium'
 
+// Dual-target build:
+//   VITE_BUILD_TARGET=web      → hosted (Cloudflare Pages, mounted at /log-viewer/
+//                                via a path-stripping Worker — see ../website/)
+//   VITE_BUILD_TARGET=desktop  → packaged for Electron, file:// loads
+//
+// `base: './'` makes index.html references relative to the page URL, so the
+// same dist/ works for both targets:
+//   - Electron: file:///.../dist/index.html → resolves ./assets/* locally
+//   - Web:      mydomain.com/log-viewer/    → resolves to .../log-viewer/assets/*
+//                                             (Worker strips → Pages serves dist/)
+// If we later add path-based routing inside the SPA (e.g. /log-viewer/share/abc),
+// switch to `base: '/log-viewer/'` and add a post-build step to flatten
+// vite-plugin-cesium's nested output. For now, query-param sharing keeps things
+// simple.
 export default defineConfig({
   plugins: [react(), cesium()],
   base: './',


### PR DESCRIPTION
## Summary
- Same source tree builds for both Electron and Cloudflare Pages, sharing `base: './'` so `dist/` works for both `file://` loading and path-prefix hosting (a Worker on the customer site strips `/log-viewer/` and forwards to Pages).
- Split scripts into `dev:web` / `build` (web) and `dev` / `build:desktop` / `dist` (Electron); `cross-env` wires `VITE_BUILD_TARGET` so runtime can gate web-only features (analytics, install prompts) cleanly.
- Cesium Ion token now sourced from `VITE_CESIUM_TOKEN` env var. `.env.example` documents both that and `VITE_GA_ID`.
- README split into Web (hosted) vs Desktop (Electron) sections.

This is branch #1 of the web-launch series. Subsequent branches cover landing/SEO, responsive layout, lazy-loading Cesium, GA4, PWA, and share hooks.

## Test plan
- [x] \`npm run build\` produces a clean \`dist/\` with \`./assets/\`, \`./cesium/\` (no nested \`dist/log-viewer/\`)
- [x] \`dist/index.html\` references work for the path-prefix Worker (strips \`/log-viewer/\`, forwards to Pages serving \`dist/\` at root)
- [ ] \`npm run dev:web\` (Vite alone) opens at http://localhost:5173
- [ ] \`npm run dev\` (Electron + Vite) still hot-reloads desktop app
- [ ] \`npm run dist\` produces an unbroken NSIS installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)