### PR TITLE
perf: code-split Dashboard, GlobeView, AltitudeAttitudeView

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -227,6 +227,22 @@ body {
   font-size: 13px;
 }
 
+/* Suspense fallback shown while a lazy chunk downloads. */
+.lazy-fallback {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text3);
+  font-size: 13px;
+  letter-spacing: 0.4px;
+  background: var(--bg);
+  min-height: 120px;
+}
+.lazy-fallback.attitude-view {
+  height: 220px;
+}
+
 /* ── Cesium globe HUD ── */
 .globe-hud {
   position: absolute;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,11 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, lazy, Suspense } from 'react'
 import { parseEdgeTXLog } from './utils/parseLog'
 import { loadLogFromUrl } from './utils/loadLogFromUrl'
-import Dashboard from './components/Dashboard'
+
+// Dashboard pulls in Chart.js, Leaflet, Three.js, plus its own lazy children
+// (GlobeView, AltitudeAttitudeView). Splitting it off keeps the empty-state
+// bundle small for first paint — empty state needs only React + the parser.
+const Dashboard = lazy(() => import('./components/Dashboard'))
 
 function modelName(filename) {
   return filename.replace(/\.csv$/i, '').replace(/-\d{4}-\d{2}-\d{2}-\d{6}$/, '')
@@ -172,7 +176,9 @@ export default function App() {
       )}
 
       {activeLog ? (
-        <Dashboard key={activeLog.filename} log={activeLog} />
+        <Suspense fallback={<div className="lazy-fallback">Loading viewer…</div>}>
+          <Dashboard key={activeLog.filename} log={activeLog} />
+        </Suspense>
       ) : (
         <div className={`drop-overlay${isDragOver ? ' drag-over' : ''}`}>
           <div className="drop-icon">✈</div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,10 +1,15 @@
-import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef, lazy, Suspense } from 'react'
 import FlightMap from './FlightMap'
 import SyncedChart from './SyncedChart'
 import FlightModeBar from './FlightModeBar'
 import StatsPanel from './StatsPanel'
-import AltitudeAttitudeView from './AltitudeAttitudeView'
-import GlobeView from './GlobeView'
+
+// GlobeView pulls in Cesium (external via vite-plugin-cesium) and the
+// Three.js GLB exporter. AltitudeAttitudeView pulls in the Three.js runtime.
+// Both are heavy and only needed for the active view mode — lazy chunks let
+// users on the alternate view skip the download entirely until they switch.
+const GlobeView = lazy(() => import('./GlobeView'))
+const AltitudeAttitudeView = lazy(() => import('./AltitudeAttitudeView'))
 
 const SPEEDS = [0.1, 0.5, 1, 2, 5, 10, 30, 60]
 
@@ -171,7 +176,9 @@ export default function Dashboard({ log }) {
             /* ── 3D Globe view ── */
             log.hasGPS ? (
               <div className="globe-wrap">
-                <GlobeView key={log.filename} rows={rows} cursorIndex={cursorIndex} virtualTimeRef={virtualTimeRef} />
+                <Suspense fallback={<div className="lazy-fallback">Loading 3D globe…</div>}>
+                  <GlobeView key={log.filename} rows={rows} cursorIndex={cursorIndex} virtualTimeRef={virtualTimeRef} />
+                </Suspense>
               </div>
             ) : (
               <div className="no-gps-msg">No GPS data</div>
@@ -186,7 +193,9 @@ export default function Dashboard({ log }) {
                   <div className="no-gps-msg">No GPS data</div>
                 )}
               </div>
-              <AltitudeAttitudeView rows={rows} cursorIndex={cursorIndex} virtualTimeRef={virtualTimeRef} />
+              <Suspense fallback={<div className="lazy-fallback attitude-view">Loading attitude view…</div>}>
+                <AltitudeAttitudeView rows={rows} cursorIndex={cursorIndex} virtualTimeRef={virtualTimeRef} />
+              </Suspense>
             </>
           )}
           <StatsPanel log={log} cursorRow={cursorRow} />


### PR DESCRIPTION
## Summary
Cuts the empty-state bundle by ~84% — from 1,055 kB to 170 kB — by lazy-loading three components.

| Chunk | Size | When it loads |
|---|---|---|
| \`index.js\` | 170 kB | Always (empty state) |
| \`Dashboard.js\` | 325 kB | When a log is loaded |
| \`three.module.js\` | 349 kB | When the active view needs Three.js |
| \`AltitudeAttitudeView.js\` | 27 kB | Classic view only |
| \`GlobeView.js\` | 11 kB | 3D Globe view only |

Before: every visitor downloaded React + Three + Chart.js + Leaflet + Cesium-bridge code regardless of whether they ever opened a log. Now the empty state ships only what's needed to parse and render itself.

Three boundaries:
- \`App.jsx\` lazy-loads \`Dashboard\`. Drag-and-drop, sample-flight button, and \`?log=\` share hook all kick off the Dashboard chunk on first use.
- \`Dashboard.jsx\` lazy-loads \`GlobeView\` and \`AltitudeAttitudeView\`. Three.js follows whichever view loads first; the other view never downloads it. Cesium remains external via vite-plugin-cesium.
- Each \`<Suspense>\` has a subtle "Loading…" fallback styled with the existing palette.

Stacked on \`feat/responsive-layout\` (#3).

## Test plan
- [x] \`npm run build\` produces split chunks as listed above
- [ ] Cold-load empty state — Network tab shows ~170 kB JS
- [ ] Click "Try a sample flight" — Dashboard + Three chunks load, then the globe renders
- [ ] Toggle between Classic and 3D Globe — second chunk loads on first toggle and is cached after
- [ ] \`?log=<url>\` on a fresh page still auto-loads correctly through the lazy boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)