### PR TITLE
v4.0.0: pre-flight summary modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgetx-log-parser",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "EdgeTX flight log visualizer for RC aircraft",
   "main": "electron/main.js",
   "author": "narenana",

--- a/src/App.css
+++ b/src/App.css
@@ -1242,3 +1242,270 @@ body {
 /* In fullscreen on mobile the sticky dock is no longer "fixed to viewport" —
    it's fixed to the fullscreened element. Browser handles this correctly
    because position:fixed in a :fullscreen element anchors to that element. */
+
+/* ── Pre-flight summary modal ─────────────────────────────────────────────
+   Shown immediately after a log is loaded. Forces engagement with the
+   headline numbers and gates the user into the dashboard with one
+   deliberate click. Empty-data branch lets bad logs exit gracefully.
+   All colors come from theme tokens so the modal flips with the theme. */
+
+.summary-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--shadow-overlay);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  animation: summary-fade-in 0.18s ease-out;
+}
+
+.summary-modal-card {
+  background: var(--bg2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 28px 28px 24px;
+  width: 100%;
+  max-width: 640px;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  box-shadow: 0 16px 48px var(--shadow-overlay);
+  animation: summary-scale-in 0.22s ease-out;
+}
+
+.summary-modal-header {
+  margin-bottom: 20px;
+}
+
+.summary-modal-title {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  color: var(--text);
+}
+
+.summary-modal-subtitle {
+  font-size: 13px;
+  color: var(--text3);
+  margin-top: 4px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.summary-tile {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.summary-tile-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text3);
+  margin-bottom: 6px;
+}
+
+.summary-tile-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.3px;
+  line-height: 1.15;
+}
+
+.summary-tile-unit {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text2);
+  margin-left: 2px;
+}
+
+.summary-cta {
+  width: 100%;
+  background: var(--blue);
+  color: var(--on-blue-text);
+  border: none;
+  border-radius: 8px;
+  padding: 13px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--shadow-card);
+  transition: filter 0.15s, transform 0.05s, box-shadow 0.15s;
+}
+
+.summary-cta:hover { filter: brightness(1.1); box-shadow: 0 4px 14px var(--shadow-card); }
+.summary-cta:active { transform: translateY(1px); }
+.summary-cta:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
+
+.summary-cta-secondary {
+  background: var(--bg3);
+  color: var(--text);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+.summary-cta-secondary:hover {
+  background: var(--hover-bg);
+  filter: none;
+  box-shadow: none;
+}
+
+.summary-empty {
+  text-align: center;
+  padding: 8px 0 22px;
+}
+.summary-empty-icon {
+  font-size: 46px;
+  opacity: 0.7;
+  margin-bottom: 12px;
+  line-height: 1;
+}
+.summary-empty-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+.summary-empty-msg {
+  font-size: 13px;
+  color: var(--text2);
+  max-width: 360px;
+  margin: 0 auto;
+  line-height: 1.45;
+}
+
+@keyframes summary-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes summary-scale-in {
+  from { opacity: 0; transform: scale(0.96) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ── Processing phase ───────────────────────────────────────────────────
+   Theatrical preamble. Walks through three "we're working" steps before
+   the actual summary numbers reveal. Pure animation — parsing has
+   already finished by the time the modal mounts. */
+
+.summary-processing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 24px 0 26px;
+  min-height: 220px;          /* keep card height stable through phase swap */
+  justify-content: center;
+}
+
+.summary-processing-spinner {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  border-top-color: var(--blue);
+  animation: summary-spin 0.85s linear infinite;
+}
+
+.summary-processing-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.summary-processing-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text3);
+  transition: color 0.2s;
+}
+
+.summary-processing-step.active {
+  color: var(--text);
+}
+.summary-processing-step.done {
+  color: var(--text2);
+}
+
+.summary-processing-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: var(--bg);
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text3);
+  flex-shrink: 0;
+  transition: background 0.2s, border-color 0.2s, color 0.2s;
+}
+
+.summary-processing-step.active .summary-processing-mark {
+  border-color: var(--blue);
+  color: var(--blue);
+  animation: summary-pulse 0.85s ease-in-out infinite;
+}
+
+.summary-processing-step.done .summary-processing-mark {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: var(--on-blue-text);
+}
+
+@keyframes summary-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes summary-pulse {
+  0%, 100% { transform: scale(1);    opacity: 1; }
+  50%      { transform: scale(1.18); opacity: 0.7; }
+}
+
+/* Fade in summary content as it replaces the processing animation. */
+.summary-grid,
+.summary-empty {
+  animation: summary-fade-in 0.28s ease-out;
+}
+
+/* Tighter spacing on small viewports — tiles still readable, less room
+   wasted on padding. */
+@media (max-width: 600px) {
+  .summary-modal-card {
+    padding: 22px 18px 18px;
+    border-radius: 10px;
+  }
+  .summary-grid {
+    grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+    gap: 8px;
+    margin-bottom: 18px;
+  }
+  .summary-tile {
+    padding: 10px 12px;
+  }
+  .summary-tile-value {
+    font-size: 18px;
+  }
+  .summary-modal-title {
+    font-size: 18px;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,10 @@ export default function App() {
   const [error, setError] = useState(null)
   const [loadingSample, setLoadingSample] = useState(null) // 'fixed-wing' | 'quad' | null
   const [theme, setTheme] = useState(readInitialTheme)
+  // Set of log filenames whose pre-flight summary modal has been dismissed.
+  // Lifted to App so the modal stays dismissed across tab switches (which
+  // remount Dashboard via key={log.filename}).
+  const [dismissedSummaries, setDismissedSummaries] = useState(() => new Set())
   const fileInputRef = useRef(null)
 
   // Apply the theme to <html data-theme="..."> + persist. CSS variables
@@ -173,14 +177,27 @@ export default function App() {
     e.target.value = ''
   }
 
-  const closeTab = (e, idx) => {
-    e.stopPropagation()
+  const closeAt = useCallback(idx => {
     setLogs(prev => {
       const next = prev.filter((_, i) => i !== idx)
       setActiveIndex(i => Math.min(i, Math.max(next.length - 1, 0)))
       return next
     })
+  }, [])
+
+  const closeTab = (e, idx) => {
+    e.stopPropagation()
+    closeAt(idx)
   }
+
+  const dismissSummary = useCallback(filename => {
+    setDismissedSummaries(prev => {
+      if (prev.has(filename)) return prev
+      const next = new Set(prev)
+      next.add(filename)
+      return next
+    })
+  }, [])
 
   const activeLog = logs[activeIndex]
 
@@ -248,7 +265,14 @@ export default function App() {
 
       {activeLog ? (
         <Suspense fallback={<div className="lazy-fallback">Loading viewer…</div>}>
-          <Dashboard key={activeLog.filename} log={activeLog} theme={theme} />
+          <Dashboard
+            key={activeLog.filename}
+            log={activeLog}
+            theme={theme}
+            summaryDismissed={dismissedSummaries.has(activeLog.filename)}
+            onDismissSummary={() => dismissSummary(activeLog.filename)}
+            onCloseLog={() => closeAt(activeIndex)}
+          />
         </Suspense>
       ) : (
         <div className={`drop-overlay${isDragOver ? ' drag-over' : ''}`}>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -4,6 +4,7 @@ import SyncedChart from './SyncedChart'
 import FlightModeBar from './FlightModeBar'
 import StatsPanel from './StatsPanel'
 import FullscreenButton from './FullscreenButton'
+import FlightSummaryModal from './FlightSummaryModal'
 import { track } from '../utils/analytics'
 
 // GlobeView pulls in Cesium (external via vite-plugin-cesium) and the
@@ -30,7 +31,13 @@ function ds(label, data, color, extra = {}) {
   }
 }
 
-export default function Dashboard({ log, theme = 'light' }) {
+export default function Dashboard({
+  log,
+  theme = 'light',
+  summaryDismissed = false,
+  onDismissSummary = () => {},
+  onCloseLog = () => {},
+}) {
   const [viewMode, setViewMode] = useState(2) // 1 = classic, 2 = 3D globe
   const [cursorIndex, setCursorIndex] = useState(0)
   const [playing, setPlaying] = useState(false)
@@ -169,6 +176,18 @@ export default function Dashboard({ log, theme = 'light' }) {
 
   return (
     <div className="dashboard">
+      {/* Pre-flight summary — gates the user into the viewer with a single
+          deliberate click, or offers a graceful exit on empty-data logs.
+          Dismissed-state lives in App.jsx (keyed by filename) so the modal
+          only shows once per loaded log even when tabbing between logs. */}
+      {!summaryDismissed && (
+        <FlightSummaryModal
+          log={log}
+          onProceed={onDismissSummary}
+          onCloseLog={onCloseLog}
+        />
+      )}
+
       {/* View mode toggle */}
       <div className="view-toggle-bar">
         <span className="view-toggle-label">View</span>

--- a/src/components/FlightSummaryModal.jsx
+++ b/src/components/FlightSummaryModal.jsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react'
+import { track } from '../utils/analytics'
+
+// Theatrical processing steps — parsing has already completed by the time
+// the modal mounts (it's synchronous in the parser today), but stepping
+// through these states gives the user a beat to register the tool is doing
+// work for them, and then a satisfying reveal of the actual summary.
+// Total run time = STEPS.length × STEP_MS + REVEAL_MS.
+const STEPS = [
+  'Parsing telemetry',
+  'Detecting flight events',
+  'Computing flight metrics',
+]
+const STEP_MS = 280
+const REVEAL_MS = 220
+
+/**
+ * Pre-flight summary modal.
+ *
+ * Shown immediately after a log is loaded. Forces the user to review the
+ * flight's headline numbers and proceed with one deliberate click — turning
+ * "drop CSV → confused dashboard" into "drop CSV → see at a glance whether
+ * this flight was interesting → dive in."
+ *
+ * If the log captured no meaningful telemetry (very short duration, no
+ * GPS/battery/altitude), the modal switches to an empty-state branch with
+ * a "Close this log" exit so bad-data files don't dump the user into an
+ * empty viewer.
+ *
+ * Dismissed-state lives in App.jsx (keyed by filename), so the modal only
+ * shows once per log even when the user tabs between multiple loaded logs.
+ */
+export default function FlightSummaryModal({ log, onProceed, onCloseLog }) {
+  const { stats, hasGPS, hasBattery, hasCurrent, flightModes } = log
+
+  // Heuristic: a log is "real" if it ran long enough AND has at least one
+  // telemetry channel that captured something. Tuned conservatively — we'd
+  // rather show the empty branch on a borderline case than gate a real
+  // flight behind it.
+  const hasRealData =
+    stats.duration >= 5 && (hasGPS || hasBattery || stats.maxAlt > 0)
+
+  // Processing animation: step through STEPS, then transition to 'summary'.
+  // `currentStep` is the index of the in-flight step; -1 means none yet,
+  // STEPS.length means all done.
+  const [phase, setPhase] = useState('processing') // 'processing' | 'summary'
+  const [currentStep, setCurrentStep] = useState(0)
+
+  useEffect(() => {
+    track('summary_shown', {
+      has_real_data: hasRealData,
+      duration_sec: Math.round(stats.duration ?? 0),
+    })
+
+    let cancelled = false
+    const timers = []
+
+    // Walk through each step, then after a short reveal pause, swap to
+    // the summary view. All timers cleaned up on unmount.
+    STEPS.forEach((_, i) => {
+      timers.push(setTimeout(() => {
+        if (!cancelled) setCurrentStep(i + 1)
+      }, (i + 1) * STEP_MS))
+    })
+    timers.push(setTimeout(() => {
+      if (!cancelled) setPhase('summary')
+    }, STEPS.length * STEP_MS + REVEAL_MS))
+
+    return () => {
+      cancelled = true
+      timers.forEach(clearTimeout)
+    }
+    // Run once per modal mount — App.jsx keys dismissal by filename so we
+    // only mount once per log anyway.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const model = modelFromFilename(log.filename)
+  const dateStr = dateFromFilename(log.filename)
+
+  return (
+    <div className="summary-modal-backdrop" role="dialog" aria-modal="true" aria-label="Flight summary">
+      <div className="summary-modal-card">
+        <div className="summary-modal-header">
+          <div className="summary-modal-title">Flight Summary</div>
+          <div className="summary-modal-subtitle">
+            {model}{dateStr ? ` · ${dateStr}` : ''}
+          </div>
+        </div>
+
+        {phase === 'processing' ? (
+          <div className="summary-processing" aria-live="polite">
+            <div className="summary-processing-spinner" aria-hidden="true" />
+            <ul className="summary-processing-steps">
+              {STEPS.map((label, i) => {
+                const state =
+                  i < currentStep ? 'done' :
+                  i === currentStep ? 'active' :
+                  'pending'
+                return (
+                  <li key={label} className={`summary-processing-step ${state}`}>
+                    <span className="summary-processing-mark" aria-hidden="true">
+                      {state === 'done' ? '✓' : state === 'active' ? '·' : '·'}
+                    </span>
+                    <span className="summary-processing-label">{label}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ) : hasRealData ? (
+          <>
+            <div className="summary-grid">
+              <Tile label="Duration" value={fmtDuration(stats.duration)} />
+              <Tile label="Max altitude" value={Math.round(stats.maxAlt)} unit="m" />
+              {hasGPS && (
+                <Tile label="Max speed" value={Math.round(stats.maxSpeed)} unit="km/h" />
+              )}
+              {hasGPS && stats.maxDistFromHomeKm > 0 && (
+                <Tile label="Max from home" value={fmtDistance(stats.maxDistFromHomeKm)} />
+              )}
+              {hasGPS && stats.distanceKm > 0 && (
+                <Tile label="Total distance" value={fmtDistance(stats.distanceKm)} />
+              )}
+              <Tile label="Max climb" value={stats.maxClimb.toFixed(1)} unit="m/s" />
+              <Tile label="Max sink" value={stats.maxSink.toFixed(1)} unit="m/s" />
+              {hasBattery && stats.minVoltage != null && (
+                <Tile label="Min voltage" value={stats.minVoltage.toFixed(1)} unit="V" />
+              )}
+              {hasCurrent && stats.maxCurrent > 0 && (
+                <Tile label="Max current" value={stats.maxCurrent.toFixed(1)} unit="A" />
+              )}
+              {hasCurrent && stats.maxCapacity > 0 && (
+                <Tile label="Used" value={Math.round(stats.maxCapacity)} unit="mAh" />
+              )}
+              {stats.minRSSI != null && (
+                <Tile label="Min RSSI" value={Math.round(stats.minRSSI)} unit="dB" />
+              )}
+              {stats.dominantMode && flightModes.length > 1 && (
+                <Tile
+                  label="Most-used mode"
+                  value={stats.dominantMode}
+                  unit={`${Math.round(stats.dominantPct * 100)}%`}
+                />
+              )}
+            </div>
+
+            <button
+              type="button"
+              className="summary-cta"
+              onClick={() => {
+                track('summary_proceeded')
+                onProceed()
+              }}
+              autoFocus
+            >
+              Proceed to visualisation →
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="summary-empty">
+              <div className="summary-empty-icon" aria-hidden="true">🛬</div>
+              <div className="summary-empty-title">No flight data here</div>
+              <div className="summary-empty-msg">
+                This log appears to be empty or didn&rsquo;t capture meaningful
+                telemetry. Try opening a different file.
+              </div>
+            </div>
+
+            <button
+              type="button"
+              className="summary-cta summary-cta-secondary"
+              onClick={() => {
+                track('summary_closed_empty')
+                onCloseLog()
+              }}
+              autoFocus
+            >
+              Close this log
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Tile({ label, value, unit }) {
+  return (
+    <div className="summary-tile">
+      <div className="summary-tile-label">{label}</div>
+      <div className="summary-tile-value">
+        {value}
+        {unit ? <span className="summary-tile-unit"> {unit}</span> : null}
+      </div>
+    </div>
+  )
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────
+
+function fmtDuration(sec) {
+  const m = Math.floor(sec / 60)
+  const s = Math.round(sec % 60)
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+// Switch units below 1 km so a 200 m hover doesn't read "0.20 km".
+function fmtDistance(km) {
+  if (km < 1) return `${Math.round(km * 1000)} m`
+  return `${km.toFixed(2)} km`
+}
+
+function modelFromFilename(filename) {
+  return filename
+    .replace(/\.csv$/i, '')
+    .replace(/-\d{4}-\d{2}-\d{2}-\d{6}$/, '')
+}
+
+function dateFromFilename(filename) {
+  const m = filename.match(/(\d{4}-\d{2}-\d{2})-(\d{2})(\d{2})(\d{2})/)
+  if (!m) return null
+  return `${m[1]} ${m[2]}:${m[3]}`
+}

--- a/src/utils/parseLog.js
+++ b/src/utils/parseLog.js
@@ -82,6 +82,54 @@ export function parseEdgeTXLog(text, filename) {
   const voltVals = rows.filter(r => r['RxBt(V)'] > 0).map(r => r['RxBt(V)'])
   const capVals = rows.map(r => r['Capa(mAh)'] || 0)
 
+  // ── Extra metrics for the pre-flight summary modal ────────────────────────
+  // One pass over rows: peak distance from launch (the "how far did you
+  // get" number a pilot actually cares about), peak current, worst RSSI,
+  // and dominant flight mode by row count. Kept separate from the existing
+  // stats block so the diff stays reviewable; fold into the main loop later
+  // when we move parsing to a Web Worker.
+  let maxDistFromHomeKm = 0
+  let maxCurrent = 0
+  let minRSSI = null
+  let homeLat = null
+  let homeLon = null
+  const modeCounts = {}
+  let totalModed = 0
+
+  for (const r of rows) {
+    if (r._lat != null) {
+      if (homeLat == null) {
+        homeLat = r._lat
+        homeLon = r._lon
+      } else {
+        const d = haversineKm(homeLat, homeLon, r._lat, r._lon)
+        if (d > maxDistFromHomeKm) maxDistFromHomeKm = d
+      }
+    }
+    const cu = r['Curr(A)']
+    if (typeof cu === 'number' && !isNaN(cu) && cu > maxCurrent) maxCurrent = cu
+    const rs = r['1RSS(dB)']
+    if (typeof rs === 'number' && !isNaN(rs)) {
+      if (minRSSI == null || rs < minRSSI) minRSSI = rs
+    }
+    if (r['FM']) {
+      modeCounts[r['FM']] = (modeCounts[r['FM']] || 0) + 1
+      totalModed++
+    }
+  }
+
+  let dominantMode = null
+  let dominantPct = 0
+  if (totalModed > 0) {
+    for (const [mode, count] of Object.entries(modeCounts)) {
+      const pct = count / totalModed
+      if (pct > dominantPct) {
+        dominantMode = mode
+        dominantPct = pct
+      }
+    }
+  }
+
   const stats = {
     duration: rows.length > 1 ? rows[rows.length - 1]._tSec : 0,
     maxAlt: altVals.length ? Math.max(...altVals) : 0,
@@ -90,8 +138,13 @@ export function parseEdgeTXLog(text, filename) {
     maxClimb: vspVals.length ? Math.max(...vspVals) : 0,
     maxSink: vspVals.length ? Math.min(...vspVals) : 0,
     distanceKm: totalDistKm,
+    maxDistFromHomeKm,
     minVoltage: voltVals.length ? Math.min(...voltVals) : null,
     maxCapacity: capVals.length ? Math.max(...capVals) : null,
+    maxCurrent,
+    minRSSI,
+    dominantMode,
+    dominantPct,
   }
 
   const events = detectEvents(rows)


### PR DESCRIPTION
## Summary
- Pre-flight summary modal gates the dashboard. Drop a CSV → 1 s "Parsing telemetry → Detecting flight events → Computing flight metrics" preamble → headline numbers (duration, max alt/speed/distance/from-home, climb/sink, voltage/current/used capacity, RSSI, dominant flight mode) → "Proceed to visualisation" CTA.
- Empty-data branch (very short log or no telemetry) swaps to a friendly "No flight data here" with a "Close this log" exit, so bad files don't dump into a useless dashboard.
- New parser stats: `maxDistFromHomeKm` (peak haversine from launch — the "how far did you get" number a pilot actually wants), `maxCurrent`, `minRSSI`, `dominantMode` + `dominantPct`. Folded into one extra pass; will merge into the main parse loop when parsing moves to a Web Worker.
- Dismissed-state lifted to App.jsx keyed by filename so the modal stays dismissed across tab switches (which remount Dashboard via `key={log.filename}`).
- GA events: `summary_shown` (with `has_real_data`, `duration_sec`), `summary_proceeded`, `summary_closed_empty`.
- Version bumped 3.0.0 → 4.0.0 — first release where the dashboard isn't the literal first thing every user sees post-drop.

## Test plan
- [x] Web build clean (`npm run build`)
- [x] Electron renderer build clean (`npm run build:desktop`)
- [x] Manual smoke test on `https://latest.narenana.com/log-viewer/` — both demo flights show the summary, "Proceed" gates correctly, theme toggle flips the modal, modal stays dismissed across tab switches
- [ ] Windows + Linux installers produced via `npm run dist` post-merge
- [ ] Verify the modal doesn't reappear after refresh on a previously-dismissed log (it will — that's expected; dismissal is per-session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)