### PR TITLE
feat(playback): bigger transport buttons + save/prev/next bookmarks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -875,27 +875,79 @@ body {
   margin-bottom: 8px;
 }
 
-.play-btn {
-  width: 44px;
-  height: 36px;
+.play-btn,
+.bookmark-btn {
+  width: 48px;
+  height: 42px;
   background: var(--bg3);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 8px;
   color: var(--text);
-  font-size: 16px;
+  font-size: 17px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
   flex: none;
 }
-.play-btn:hover { background: var(--hover-bg); border-color: var(--border-bright); }
+.play-btn { font-size: 18px; }
+.play-btn:hover,
+.bookmark-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+  border-color: var(--border-bright);
+}
 .play-btn.active {
   background: var(--blue);
   border-color: var(--blue);
   color: var(--on-blue-text);
   box-shadow: 0 2px 10px var(--shadow-card);
+}
+
+/* Bookmark navigation (prev / next). Visually quieter than play. */
+.bookmark-btn { font-size: 14px; }
+.bookmark-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Save-bookmark uses a star: outline (☆) when nothing here, solid (★) when
+   the cursor is on/near a bookmark. The latter is highlighted so the user
+   knows clicking again will REMOVE rather than re-save. */
+.bookmark-btn.save-bookmark {
+  font-size: 18px;
+}
+.bookmark-btn.save-bookmark.active {
+  background: var(--bg);
+  border-color: var(--orange, #d56e10);
+  color: var(--orange, #d56e10);
+  box-shadow: 0 0 0 1px var(--orange, #d56e10);
+}
+
+/* Scrubber + bookmark marker overlay */
+.scrubber-wrap {
+  position: relative;
+  width: 100%;
+}
+.bookmark-marks {
+  /* Sits over the scrubber. Doesn't intercept clicks — scrubber gets them. */
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  /* Slight inset so markers align with the visible track, not the
+     range element's full padding-box. The scrubber itself is 4 px tall
+     centred vertically, so we centre the marks too. */
+  display: flex;
+  align-items: center;
+}
+.bookmark-mark {
+  position: absolute;
+  width: 8px;
+  height: 14px;
+  margin-left: -4px;
+  background: var(--orange, #d56e10);
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px var(--bg);
 }
 
 .speed-btns {
@@ -1148,8 +1200,19 @@ body {
   .view-toggle-label { display: none; }
   .view-toggle-btn { padding: 4px 10px; font-size: 11px; min-height: 28px; }
 
-  /* Larger touch targets for playback. */
-  .play-btn { width: 40px; height: 36px; font-size: 16px; }
+  /* Larger touch targets for playback — Apple HIG recommends 44 px
+     minimum on iOS. Going slightly bigger on phones because thumb
+     accuracy on a sticky bottom bar is worse than a precise click. */
+  .play-btn,
+  .bookmark-btn {
+    width: 52px;
+    height: 48px;
+    font-size: 18px;
+    border-radius: 10px;
+  }
+  .play-btn { font-size: 20px; }
+  .bookmark-btn { font-size: 16px; }
+  .bookmark-btn.save-bookmark { font-size: 22px; }
 
   /* Speed picker collapses to a single chip on phones — see .speed-picker
      below. The full pill row stays in the DOM for screen-reader access; CSS

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -44,7 +44,11 @@ export default function Dashboard({ log, theme = 'light' }) {
   const [bookmarks, setBookmarks] = useState([]) // sorted ascending row indices
   const speedRef = useRef(speed)
   const virtualTimeRef = useRef(0)
+  // Mirror bookmarks into a ref so the rAF playback loop can read the
+  // latest list without restarting every time the array changes.
+  const bookmarksRef = useRef(bookmarks)
   useEffect(() => { speedRef.current = speed }, [speed])
+  useEffect(() => { bookmarksRef.current = bookmarks }, [bookmarks])
 
   const { rows, events } = log
 
@@ -158,6 +162,23 @@ export default function Dashboard({ log, theme = 'light' }) {
         }
         let next = prev
         while (next < rows.length - 1 && rows[next + 1]._tSec <= vt) next++
+        // Pause on bookmark crossing. We only fire when the cursor has
+        // ADVANCED into a bookmark — i.e. there's a bookmark strictly
+        // greater than `prev` and at-or-before `next`. Pressing play
+        // while parked on a bookmark therefore doesn't immediately
+        // re-pause; we keep going until we cross the NEXT one.
+        if (next > prev) {
+          const bms = bookmarksRef.current
+          // bms is sorted ascending — first match is the closest one
+          // we just rolled past.
+          const hit = bms.find(b => b > prev && b <= next)
+          if (hit != null) {
+            setPlaying(false)
+            virtualTimeRef.current = rows[hit]._tSec
+            track('bookmark_auto_pause')
+            return hit
+          }
+        }
         // React bails on a state set if the value is identical, so frames
         // where the source row didn't change are essentially free.
         return next

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -41,11 +41,75 @@ export default function Dashboard({ log, theme = 'light' }) {
   const [playing, setPlaying] = useState(false)
   const [speed, setSpeed] = useState(1)
   const [speedExpanded, setSpeedExpanded] = useState(false)
+  const [bookmarks, setBookmarks] = useState([]) // sorted ascending row indices
   const speedRef = useRef(speed)
   const virtualTimeRef = useRef(0)
   useEffect(() => { speedRef.current = speed }, [speed])
 
   const { rows, events } = log
+
+  // ── Bookmarks: per-log, persisted to localStorage ───────────────────────────
+  // Stable fingerprint = filename + row-count + first-row-tSec. Two
+  // different logs with the same filename (recorded after a reset, or
+  // re-opened after re-parsing) get distinct keys via the row metadata.
+  const bookmarkKey = useMemo(() => {
+    const fname = log.filename || 'untitled'
+    const t0 = rows[0]?._tSec ?? 0
+    return `bm:${fname}:${rows.length}:${Math.round(t0)}`
+  }, [log.filename, rows])
+
+  // Load bookmarks when the log (or its fingerprint) changes.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(bookmarkKey)
+      const parsed = raw ? JSON.parse(raw) : []
+      setBookmarks(Array.isArray(parsed) ? parsed.filter(i => Number.isInteger(i) && i >= 0 && i < rows.length) : [])
+    } catch { setBookmarks([]) }
+  }, [bookmarkKey, rows.length])
+
+  // Save bookmarks on change. Skip the very first run (initial empty array
+  // from useState) — the load effect above writes the canonical value.
+  const bmFirstRun = useRef(true)
+  useEffect(() => {
+    if (bmFirstRun.current) { bmFirstRun.current = false; return }
+    try { localStorage.setItem(bookmarkKey, JSON.stringify(bookmarks)) } catch {}
+  }, [bookmarkKey, bookmarks])
+
+  // True when the current cursor position matches an existing bookmark
+  // (within a small tolerance of ±2 rows, so users don't have to land on
+  // the exact same frame to "remove" it).
+  const cursorOnBookmark = useMemo(() => {
+    return bookmarks.some(i => Math.abs(i - cursorIndex) <= 2)
+  }, [bookmarks, cursorIndex])
+
+  const saveBookmark = useCallback(() => {
+    setBookmarks(prev => {
+      // Toggle: if cursor is on (or near) an existing bookmark, remove it
+      const near = prev.find(i => Math.abs(i - cursorIndex) <= 2)
+      if (near != null) {
+        track('bookmark_removed')
+        return prev.filter(i => i !== near)
+      }
+      track('bookmark_saved', { count: prev.length + 1 })
+      return [...prev, cursorIndex].sort((a, b) => a - b)
+    })
+  }, [cursorIndex])
+
+  const jumpToBookmark = useCallback((direction) => {
+    if (bookmarks.length === 0) return
+    let target
+    if (direction === 'next') {
+      target = bookmarks.find(i => i > cursorIndex)
+      if (target == null) target = bookmarks[0]                  // wrap → first
+    } else {
+      target = [...bookmarks].reverse().find(i => i < cursorIndex)
+      if (target == null) target = bookmarks[bookmarks.length - 1] // wrap → last
+    }
+    setCursorIndex(target)
+    virtualTimeRef.current = rows[target]._tSec
+    setPlaying(false)
+    track('bookmark_jumped', { direction })
+  }, [bookmarks, cursorIndex, rows])
 
   // ── Per-log analytics summary (privacy-safe aggregates only) ────────────────
   // Fired once per loaded log. No GPS, no flight content — just shape metrics
@@ -269,6 +333,16 @@ export default function Dashboard({ log, theme = 'light' }) {
         {/* Playback controls */}
         <div className="playback-row">
           <button
+            className="bookmark-btn nav-btn-prev"
+            onClick={() => jumpToBookmark('prev')}
+            disabled={bookmarks.length === 0}
+            title="Jump to previous bookmark"
+            aria-label="Jump to previous bookmark"
+          >
+            ⏮
+          </button>
+
+          <button
             className={`play-btn${playing ? ' active' : ''}`}
             onClick={() => {
               setPlaying(p => {
@@ -280,6 +354,26 @@ export default function Dashboard({ log, theme = 'light' }) {
             title="Play / Pause (Space)"
           >
             {playing ? '⏸' : '▶'}
+          </button>
+
+          <button
+            className="bookmark-btn nav-btn-next"
+            onClick={() => jumpToBookmark('next')}
+            disabled={bookmarks.length === 0}
+            title="Jump to next bookmark"
+            aria-label="Jump to next bookmark"
+          >
+            ⏭
+          </button>
+
+          <button
+            className={`bookmark-btn save-bookmark${cursorOnBookmark ? ' active' : ''}`}
+            onClick={saveBookmark}
+            title={cursorOnBookmark ? 'Remove bookmark here' : 'Save bookmark at current position'}
+            aria-label={cursorOnBookmark ? 'Remove bookmark here' : 'Save bookmark at current position'}
+            aria-pressed={cursorOnBookmark}
+          >
+            {cursorOnBookmark ? '★' : '☆'}
           </button>
 
           {/* Speed picker — full row of pills on desktop, single chip
@@ -327,20 +421,36 @@ export default function Dashboard({ log, theme = 'light' }) {
           onEventClick={type => track('event_marker_clicked', { type })}
         />
 
-        {/* Timeline scrubber */}
-        <input
-          type="range"
-          className="timeline-scrubber"
-          min={0}
-          max={rows.length - 1}
-          value={cursorIndex}
-          onChange={e => {
-            const idx = Number(e.target.value)
-            setCursorIndex(idx)
-            virtualTimeRef.current = rows[idx]._tSec
-            setPlaying(false)
-          }}
-        />
+        {/* Timeline scrubber + bookmark markers. Markers sit in an
+            overlay div positioned over the scrubber — they don't
+            intercept clicks (pointer-events: none in CSS) so the
+            scrubber's drag still works through them. */}
+        <div className="scrubber-wrap">
+          <input
+            type="range"
+            className="timeline-scrubber"
+            min={0}
+            max={rows.length - 1}
+            value={cursorIndex}
+            onChange={e => {
+              const idx = Number(e.target.value)
+              setCursorIndex(idx)
+              virtualTimeRef.current = rows[idx]._tSec
+              setPlaying(false)
+            }}
+          />
+          {bookmarks.length > 0 && (
+            <div className="bookmark-marks" aria-hidden="true">
+              {bookmarks.map(idx => (
+                <span
+                  key={idx}
+                  className="bookmark-mark"
+                  style={{ left: `${(idx / (rows.length - 1)) * 100}%` }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Three new transport buttons: **⏮ prev bookmark**, **⏭ next bookmark**, **☆/★ save bookmark**
- **Toggle behaviour**: clicking save when cursor is on a bookmark removes it (±2-row tolerance so users don't have to land exact)
- **Wrap-around**: next from last → first, prev from first → last
- **Persists per-log** to localStorage, keyed by \`bm:<filename>:<row-count>:<first-row-tSec>\`
- **Bigger touch targets**: desktop play/bookmark btns 44×36 → 48×42, mobile 40×36 → 52×48 (>Apple HIG 44 px minimum)
- **Markers** on the timeline scrubber render as orange pills so users see where their bookmarks are at a glance
- Sticky-bottom dock on mobile unchanged

## Test plan
- [x] tests/visualisation/probe-bookmarks.js: save → marker → localStorage → next/prev → wrap → toggle-remove all pass
- [x] desktop button sizes confirmed 48×42
- [x] mobile @media rules verified present (rule for play-btn + bookmark-btn @ 52×48)
- [ ] manual eyeball on latest.narenana.com after deploy
- [ ] manual mobile test: thumb-tap each transport button, no mis-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)