### PR TITLE
feat(observability): Sentry crash reporting + GA4 Consent Mode v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,11 @@
 VITE_CESIUM_TOKEN=
 
 # Google Analytics 4 measurement ID (e.g. G-XXXXXXXXXX). Web build only.
-# When set, GA4 + Consent Mode v2 wires up at runtime. Empty → no analytics,
-# and the consent banner doesn't render.
+# When set, GA4 + Consent Mode v2 wires up at runtime in COOKIELESS mode
+# on every page load. The consent banner asks permission to upgrade to
+# full collection (sets the _ga cookie). Empty → no analytics.
 #
-# Events fired (after explicit consent):
+# Events fired:
 #   app_view              — once when consent is granted
 #   log_loaded            — { source: 'file' | 'sample' | 'shared-url',
 #                             count?, sample_type? }
@@ -25,3 +26,43 @@ VITE_CESIUM_TOKEN=
 #   event_marker_clicked  — { type: 'takeoff' | 'rth_on' | 'rth_off' | 'land' }
 #   camera_mode_toggled   — { mode: 'auto' | 'manual' } (3D globe)
 VITE_GA_ID=
+
+# Sentry error reporting DSN. Web build only. Empty → no error reporting,
+# the consent banner doesn't mention crash reports.
+#
+# When set, Sentry boots on every page load in always-anonymous mode:
+#   - sendDefaultPii: false
+#   - IP scrubbed in beforeSend (never want it)
+#   - URL query strings stripped (might leak filenames)
+#   - Default breadcrumbs (clicks, console) DISABLED before consent
+#
+# When the user clicks Accept on the consent banner, breadcrumbs are
+# enabled so future errors carry context. IP and URL are still scrubbed.
+#
+# What gets reported:
+#   - Uncaught exceptions / unhandled promise rejections (always)
+#   - Parse failures via captureParseError() with file size, firmware
+#     version, and frame schema field names — never log content
+#
+# Get your DSN from https://sentry.io after creating a React project.
+# Format: https://<key>@o<orgid>.ingest.sentry.io/<projid>
+VITE_SENTRY_DSN=
+
+# Build-time release tag, stamped into Sentry events so we can attribute
+# crashes to a specific deploy. The Cloudflare Pages build sets
+# CF_PAGES_COMMIT_SHA — wire that through (e.g.
+# `VITE_RELEASE=$CF_PAGES_COMMIT_SHA npm run build`). Empty → release "dev".
+VITE_RELEASE=
+
+# Sentry source-map upload (build-time only — not exposed to clients).
+# Without these, Sentry still receives errors but stack traces are
+# minified. Set all three to enable upload via @sentry/vite-plugin.
+#
+# SENTRY_AUTH_TOKEN: Sentry user/internal auth token with project:write
+#                    + project:releases scopes. Get from
+#                    https://sentry.io/settings/account/api/auth-tokens/
+# SENTRY_ORG:        org slug (e.g. "narenana")
+# SENTRY_PROJECT:    project slug (e.g. "rc-log-viewer")
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/README.md
+++ b/README.md
@@ -203,9 +203,10 @@ The viewer pulls together a few major pieces of OSS and a handful of public mapp
 - **[Electron 31](https://www.electronjs.org/)** + **[electron-builder](https://www.electron.build/)** package the desktop app (Mac/Windows/Linux).
 - **[Workbox](https://developer.chrome.com/docs/workbox)** (via Vite's PWA plugin) caches the app shell + Cesium runtime so the web build works offline after first visit.
 
-### Analytics
+### Analytics & error reporting
 
-- **[Google Analytics 4](https://developers.google.com/analytics/devguides/collection/ga4)** (gtag.js) for anonymous usage stats. Strictly **opt-in** — `analytics.js` only loads `googletagmanager.com` after the consent banner is accepted. No tracking, no user IDs, no log content ever leaves the browser; the events are page views and high-level "log loaded / view switched" markers.
+- **[Google Analytics 4](https://developers.google.com/analytics/devguides/collection/ga4)** (gtag.js) for anonymous usage stats. Loaded on every page in **Consent Mode v2 cookieless-ping mode** — anonymous aggregate hits, no `_ga` cookie. The consent banner asks permission to upgrade to full collection (cookied analytics). Decline = stay cookieless. No log content ever leaves the browser.
+- **[Sentry](https://sentry.io/)** (`@sentry/react`) for crash reporting. Boots on every page in **always-anonymous mode**: no PII, IPs scrubbed, URL query strings stripped. Default-disabled breadcrumbs upgrade to enabled when consent is granted, so post-accept errors carry click/console context. Parse failures attach privacy-safe metadata (file size, firmware revision, schema field names) — never log content. Full disclosure in [`SENTRY.md`](SENTRY.md).
 
 ---
 
@@ -240,6 +241,9 @@ Both targets share `base: './'`, so the same `dist/` works for `file://` (Electr
 **Env vars** — `.env.example` lists them. All `VITE_*` vars are inlined into the client bundle at build time:
 - `VITE_CESIUM_TOKEN` — Cesium Ion access token (optional; falls back to ephemeral key)
 - `VITE_GA_ID` — GA4 measurement ID (web build only; empty disables analytics)
+- `VITE_SENTRY_DSN` — Sentry DSN (web build only; empty disables crash reporting)
+- `VITE_RELEASE` — release tag for Sentry events (commit SHA; empty → "dev")
+- `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` — build-time only (NOT prefixed `VITE_`, never sent to clients); enable source-map upload
 
 For the full list of pieces we lean on (with their external partners), see [Built with](#built-with) above.
 

--- a/SENTRY.md
+++ b/SENTRY.md
@@ -1,0 +1,80 @@
+# Error reporting — what we collect, when, and why
+
+This viewer uses [Sentry](https://sentry.io/) to capture crashes anonymously
+so they can be debugged. This page is the human-readable summary of exactly
+what gets sent. The implementation is in
+[`src/utils/sentry.js`](src/utils/sentry.js).
+
+## Loading model
+
+Sentry boots on every page load (when `VITE_SENTRY_DSN` is set) in
+**always-anonymous mode** — no PII, no IP address, URL query strings
+stripped, no user-action breadcrumbs. The "consent banner" you see on first
+visit is **not** asking permission to run Sentry; it asks permission to
+attach breadcrumbs (which buttons you clicked) to future error reports.
+
+| | Before consent (default) | After Accept | After Decline |
+|---|---|---|---|
+| Crash reports | ✓ anonymous | ✓ anonymous | ✓ anonymous |
+| IP address | scrubbed | scrubbed | scrubbed |
+| URL query strings | scrubbed | scrubbed | scrubbed |
+| Breadcrumbs (click / console) | not collected | collected | not collected |
+| `_ga` analytics cookie | not set | set | not set |
+| GA4 cookieless pings | sent | upgraded to full | continue cookieless |
+
+To turn Sentry off entirely, leave `VITE_SENTRY_DSN` empty in the build
+environment. The whole module compiles to a no-op in that case.
+
+## What gets sent on a crash
+
+A crash report contains, at most:
+- The error message and JavaScript stack trace
+- The browser/OS user-agent string (Sentry's default; we don't add to it)
+- The HTTP referrer + URL **with query string removed**
+- The build's release tag (commit SHA — `VITE_RELEASE`)
+- Click/console breadcrumbs only **if you accepted consent** before the crash
+
+When the crash is a flight-log parse failure (both Rust and C parsers
+rejected your file), the report ALSO carries:
+- File size in bytes
+- Filename **basename only** (no directory path)
+- Firmware revision string from the log header (e.g. `INAV 9.0.1`)
+- Frame schema field names (the column list, e.g. `["loopIteration","time","axisP[0]"]`)
+- The parser error message
+
+This metadata is what's needed to reproduce a parser bug — we can hand it to
+the firmware-side maintainers (iNAV, Betaflight, blackbox-log) without
+touching your actual flight data.
+
+## What never gets sent
+
+- The bytes of any flight log
+- GPS coordinates from your log
+- Your IP address (scrubbed in `beforeSend`)
+- Email, name, or any account identifier (the viewer has no auth)
+- URL query strings (might contain shared-log identifiers)
+
+## Code references
+
+- `src/utils/sentry.js` — init, beforeSend scrubbing, captureParseError
+- `src/utils/parseBlackbox.js` — calls captureParseError when both parsers fail
+- `src/components/ConsentBanner.jsx` — the UI prompt
+- `src/utils/analytics.js` — calls upgradeSentryConsent on Accept
+
+## Turning it off
+
+In a build environment, leave `VITE_SENTRY_DSN` empty.
+
+In a running browser session, opening DevTools and clearing
+`localStorage.analytics-consent-v1` brings the banner back; clicking
+Decline keeps Sentry running but in the most-anonymous configuration
+(no breadcrumbs ever attached).
+
+## Source maps
+
+The build pipeline uploads source maps to Sentry at deploy time
+(`@sentry/vite-plugin` runs when `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` +
+`SENTRY_PROJECT` are set in CI). The maps are deleted from `dist/`
+after upload, so users never download them. This lets stack traces in
+the Sentry UI resolve to readable React component names instead of
+minified `(c5)→(b3)` symbols.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "edgetx-log-parser",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edgetx-log-parser",
-      "version": "4.0.0",
+      "version": "5.0.0",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@sentry/react": "^10.51.0",
+        "@sentry/vite-plugin": "^5.2.1",
         "blackbox-parser": "file:./vendor/blackbox-parser",
         "cesium": "^1.140.0",
         "chart.js": "^4.4.2",
@@ -44,7 +47,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -59,7 +61,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -69,7 +70,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -100,7 +100,6 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -130,7 +129,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -204,7 +202,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -228,7 +225,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -242,7 +238,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -333,7 +328,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -343,7 +337,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -353,7 +346,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -378,7 +370,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -392,7 +383,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1552,7 +1542,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -1567,7 +1556,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -1586,7 +1574,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2467,7 +2454,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2478,7 +2464,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2489,7 +2474,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2510,14 +2494,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3180,6 +3162,446 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.51.0.tgz",
+      "integrity": "sha512-lNKBS4P7RUvf1niojXQWe9bU3gnBUCbST4Dj0pSiyat1N96cXVyHkeE+uGxowD0RrVWhs+kGHiVX3FcmRWF6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.51.0.tgz",
+      "integrity": "sha512-bCM95bcpphx28e6aU0bwRLxOgwosYsdNzezM1sM0pVOkb0TB3hDFRamramVDK+/Hp1o8qmRxS4c5w/A7YBZGkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.51.0.tgz",
+      "integrity": "sha512-jCpI5HXSwK6ZT2HX70+mDRciAocHzSiDk4DTgvzV69Wvd+Ei5WLgE+d39eaEPsm8lUC0Ydntb5sJIB6uG9D4bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.51.0.tgz",
+      "integrity": "sha512-8PW1Pp+Yl3lPwYqhBCr5SgkuhDanu9ZLzUqD2bPKL/ElqbM2eDVIWxq4z4ZzePrmZa6IcCjTv6sVQJ7Z4dLyLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.1.tgz",
+      "integrity": "sha512-QQ9AL5EXIbSK26ObLVtiU6l3tCUdpGSJ/6VwDkPhC3qvtoksSlcoU9Yzm7XC0NBcvu1N2abL5R7gckKGZ4JewQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.51.0.tgz",
+      "integrity": "sha512-Zdc0sKfenxUtW/OGhtJ7xHFN44bXR7YqxJ1zBDzlZfW0nTbeTTUZBq9z5NUw6qdS0Vs/i3V4qzAKTbRKWfqSEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.51.0",
+        "@sentry-internal/feedback": "10.51.0",
+        "@sentry-internal/replay": "10.51.0",
+        "@sentry-internal/replay-canvas": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.2.1.tgz",
+      "integrity": "sha512-uXb+TOZKXxm2STsP3iR70Jh/yYHwlHOvql7w/bUVYgDyiB/1Mv0D6oNGS0kelsgBsBwCq3ngyJYlyNy3oM1pPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/babel-plugin-component-annotate": "5.2.1",
+        "@sentry/cli": "^2.58.5",
+        "dotenv": "^16.3.1",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@sentry/bundler-plugin-core/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
+      "integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.5",
+        "@sentry/cli-linux-arm": "2.58.5",
+        "@sentry/cli-linux-arm64": "2.58.5",
+        "@sentry/cli-linux-i686": "2.58.5",
+        "@sentry/cli-linux-x64": "2.58.5",
+        "@sentry/cli-win32-arm64": "2.58.5",
+        "@sentry/cli-win32-i686": "2.58.5",
+        "@sentry/cli-win32-x64": "2.58.5"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
+      "integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
+      "integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
+      "integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
+      "integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
+      "integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
+      "integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
+      "integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
+      "integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+      "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.51.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.51.0.tgz",
+      "integrity": "sha512-RRHHqjNvjji6ebIqdlAr453AkST8Vm4cxdu1vWm772IgbzTO7Jx46Cj6Bt2/GjMyH0YLE5euDaAOQhFMmpvAOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.51.0",
+        "@sentry/core": "10.51.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/rollup-plugin": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.2.1.tgz",
+      "integrity": "sha512-LKJyL4fzcHnHExipVN0/QinhBNoGZt+UXg8xJaqc6MwOolOhxHW0ii2hu1OZsiOhX0+r9MK7T+a7Sx0F0bzdMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.2.1",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/rollup-plugin/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.2.1.tgz",
+      "integrity": "sha512-sSQzOhN8xvo/R70vqgyonnC/fwXpJ1kbkJ0g81Xy/OR+N89+v5tPN4VlKTAq3T2c5yAPE39XCbdgeEnI4kbWGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugin-core": "5.2.1",
+        "@sentry/rollup-plugin": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3777,7 +4199,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -4258,7 +4679,6 @@
       "version": "2.10.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
       "integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4356,7 +4776,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4601,7 +5020,6 @@
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
       "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4960,7 +5378,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
@@ -5143,7 +5560,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5686,7 +6102,6 @@
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5918,7 +6333,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6063,6 +6477,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/follow-redirects": {
@@ -6277,7 +6707,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6720,7 +7149,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -7324,7 +7752,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
@@ -7412,7 +7839,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -7447,7 +7873,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -7577,6 +8002,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -7670,7 +8110,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -7879,11 +8318,52 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -8009,6 +8489,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -8035,6 +8545,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -8191,7 +8710,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8807,7 +9325,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9991,7 +10508,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10320,7 +10836,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11023,7 +11538,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
@@ -11064,6 +11578,18 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     }
   },
   "dependencies": {
+    "@sentry/react": "^10.51.0",
+    "@sentry/vite-plugin": "^5.2.1",
     "blackbox-parser": "file:./vendor/blackbox-parser",
     "cesium": "^1.140.0",
     "chart.js": "^4.4.2",

--- a/src/components/ConsentBanner.jsx
+++ b/src/components/ConsentBanner.jsx
@@ -1,19 +1,33 @@
 import { useEffect, useState } from 'react'
 import { getConsent, setConsent, isAnalyticsAvailable } from '../utils/analytics'
+import { isSentryAvailable } from '../utils/sentry'
 
 /**
- * One-time consent banner for GA4. Renders nothing if:
- *   - Analytics is unavailable (desktop build, or no VITE_GA_ID)
+ * One-time consent banner for analytics + error reporting. Renders nothing if:
+ *   - Both analytics and Sentry are unavailable (desktop build, or neither
+ *     env var set)
  *   - User has already chosen (granted or denied) — choice is in localStorage
  *
- * Accept / Decline are equal-weight; no dark patterns.
+ * What "Accept" / "Decline" actually do:
+ *   - Decline: nothing changes. Analytics is already running in cookieless
+ *     "ping" mode (no _ga cookie, anonymous aggregate hits) and error
+ *     reports are already running in anonymous mode (no IP, no PII).
+ *     The banner just disappears.
+ *   - Accept: analytics upgrades to full collection (sets the _ga cookie,
+ *     full event params), and error reports start carrying breadcrumbs
+ *     (console + clicks) so future crashes have context. IP and URL query
+ *     strings remain scrubbed in error reports either way.
+ *
+ * This is the "Consent Mode degraded" model — both tools are always on
+ * in privacy-respecting mode; the banner asks for permission to upgrade
+ * to fuller collection. See SENTRY.md for the full disclosure.
  */
 export default function ConsentBanner() {
   const [visible, setVisible] = useState(false)
   const [showPolicy, setShowPolicy] = useState(false)
 
   useEffect(() => {
-    if (!isAnalyticsAvailable()) return
+    if (!isAnalyticsAvailable() && !isSentryAvailable()) return
     if (getConsent() !== null) return
     setVisible(true)
   }, [])
@@ -26,10 +40,10 @@ export default function ConsentBanner() {
   }
 
   return (
-    <div className="consent-banner" role="dialog" aria-label="Analytics consent">
+    <div className="consent-banner" role="dialog" aria-label="Analytics and error reporting consent">
       <p className="consent-copy">
-        Anonymous analytics help me improve the tool. Your flight logs are
-        never sent — only which features you used.{' '}
+        Anonymous analytics and crash reports help me improve the tool. Your
+        flight logs are never sent — only aggregate usage and error details.{' '}
         <button
           type="button"
           className="consent-policy-toggle"
@@ -41,12 +55,24 @@ export default function ConsentBanner() {
       </p>
 
       {showPolicy && (
-        <p className="consent-policy">
-          <strong>Collected:</strong> page views, clicks on the sample-flight
-          button, view-mode toggles between Classic and 3D Globe.{' '}
-          <strong>Not collected:</strong> the CSV content, GPS coordinates,
-          flight paths, or anything else from your log file.
-        </p>
+        <div className="consent-policy">
+          <p>
+            <strong>Always anonymous (whether you accept or decline):</strong>{' '}
+            aggregate page-view counts (no cookies until you accept), and crash
+            reports with no IP address, no email, no log content. Crash reports
+            include only file size, firmware version, and the parser error
+            message — never the actual log bytes.
+          </p>
+          <p>
+            <strong>If you accept:</strong> a cookie is set to deduplicate page
+            views, and crash reports include breadcrumbs (which buttons you
+            clicked before the crash) to help me debug.
+          </p>
+          <p>
+            <strong>Never collected:</strong> the CSV / blackbox content, GPS
+            coordinates, flight paths, or anything else from your log file.
+          </p>
+        </div>
       )}
 
       <div className="consent-actions">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,9 +3,68 @@ import ReactDOM from 'react-dom/client'
 import 'leaflet/dist/leaflet.css'
 import './App.css'
 import App from './App'
+import { initSentry, SentryErrorBoundary } from './utils/sentry'
+import { bootGaDegraded } from './utils/analytics'
+
+// Boot error reporting + analytics in their respective "degraded" modes
+// before React renders. Both are no-ops if their env vars (VITE_SENTRY_DSN
+// / VITE_GA_ID) are unset, so this is safe in dev and Electron.
+//
+// Sentry runs in always-anonymous mode (no PII, no IP, scrubbed URLs).
+// Analytics runs in Consent Mode v2 cookieless-ping mode (anonymous
+// aggregate hits, no _ga cookie). Both upgrade to fuller collection
+// when the user clicks Accept on ConsentBanner.
+initSentry()
+bootGaDegraded()
+
+// Fallback UI when an uncaught React render error reaches the boundary.
+// We keep it minimal — a "something went wrong" panel with a reload
+// button. The error has already been sent to Sentry by this point.
+function ErrorFallback({ error, resetError }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: '2rem',
+        maxWidth: '40rem',
+        margin: '4rem auto',
+        fontFamily: 'system-ui, sans-serif',
+        color: '#e6e6e6',
+        background: '#1a1d23',
+        border: '1px solid #2a2f37',
+        borderRadius: '8px',
+      }}
+    >
+      <h2 style={{ marginTop: 0 }}>Something broke</h2>
+      <p>The viewer hit an unexpected error and can&apos;t continue. The crash has been reported anonymously so it can be fixed.</p>
+      <p style={{ fontSize: '0.85rem', opacity: 0.7, fontFamily: 'monospace' }}>
+        {error?.message || String(error)}
+      </p>
+      <button
+        type="button"
+        onClick={() => {
+          resetError()
+          window.location.reload()
+        }}
+        style={{
+          padding: '0.5rem 1rem',
+          background: '#3b82f6',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        }}
+      >
+        Reload
+      </button>
+    </div>
+  )
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <SentryErrorBoundary fallback={ErrorFallback}>
+      <App />
+    </SentryErrorBoundary>
   </React.StrictMode>
 )

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,21 +1,50 @@
 /**
- * Google Analytics 4 with privacy-first Consent Mode v2.
+ * Google Analytics 4 with Consent Mode v2.
+ *
+ * Loading model (Option B — "Consent Mode degraded"):
+ *
+ *   - On page load (regardless of consent decision):
+ *       gtag.js is fetched and the dataLayer is set up with all consent
+ *       categories DENIED. In this state GA4 sends "cookieless pings" —
+ *       no _ga cookie is set, no client ID is persisted, the server
+ *       receives anonymous aggregate hits only. This is what Google's
+ *       Consent Mode v2 calls "advanced" / "modeled" mode.
+ *
+ *   - When the user clicks Accept on the consent banner:
+ *       gtag('consent','update',{analytics_storage:'granted',...}) flips
+ *       on full collection — the _ga cookie is set, full event params
+ *       ride with future hits.
+ *
+ *   - When the user clicks Decline:
+ *       Consent stays denied. We continue receiving cookieless pings
+ *       (already happening), but the user has explicitly opted out of
+ *       cookies. We respect that — the deny path doesn't disable GA,
+ *       it just stays in the cookieless mode it was already in.
  *
  * Hard no-ops unless ALL of:
  *   - VITE_BUILD_TARGET === 'web'    (skip Electron)
  *   - VITE_GA_ID is set              (skip if env unset)
- *   - user has granted consent       (skip until ConsentBanner accepts)
  *
- * gtag.js is loaded dynamically the first time consent is granted — never
- * via a static <script> tag in index.html. This keeps the empty-state
- * bundle clean and ensures users who decline never load any GA code.
+ * The presence of the ConsentBanner is now decoupled from "should GA
+ * exist at all?" — GA always exists in degraded mode if the env var is
+ * set; the banner just gates the upgrade to full collection.
+ *
+ * Note: under strict GDPR / EU DPA interpretations, Consent Mode v2's
+ * cookieless pings are still arguable as "processing requiring consent."
+ * Google's stance is that the aggregate-only signal is non-personal and
+ * exempt. If a user (or our jurisdiction) requires hard opt-in, flip
+ * back to opt-in mode by removing the bootGaDegraded() call from main.jsx
+ * and reverting setConsent('granted') to call initAnalytics() instead.
  */
+
+import { upgradeSentryConsent } from './sentry'
 
 const CONSENT_KEY = 'analytics-consent-v1'
 const GA_ID = import.meta.env.VITE_GA_ID
 const IS_WEB = import.meta.env.VITE_BUILD_TARGET === 'web'
 
-let initialized = false
+let degradedBooted = false
+let upgraded = false
 let pendingEvents = []
 
 export function getConsent() {
@@ -32,30 +61,33 @@ export function setConsent(value) {
     // Private mode / quota — non-fatal.
   }
   if (value === 'granted') {
-    initAnalytics()
+    upgradeAnalytics()
+    upgradeSentryConsent()
     track('app_view')
   }
+  // 'denied' just persists the choice; we stay in cookieless degraded mode.
 }
 
 export function isAnalyticsAvailable() {
   return IS_WEB && !!GA_ID
 }
 
-export function initAnalytics() {
-  if (initialized) return
+/**
+ * Boot GA4 in cookieless / Consent Mode v2 degraded state.
+ * Called once from main.jsx on every page load.
+ */
+export function bootGaDegraded() {
+  if (degradedBooted) return
   if (!IS_WEB || !GA_ID) return
-  if (getConsent() !== 'granted') return
+  degradedBooted = true
 
-  initialized = true
-
-  // Set up the dataLayer + gtag stub before the script loads. Consent Mode
-  // v2 starts with everything denied; we then update analytics_storage to
-  // granted (the user has just clicked Accept).
   window.dataLayer = window.dataLayer || []
   window.gtag = function () {
     window.dataLayer.push(arguments)
   }
 
+  // Set Consent Mode v2 default state: everything denied. This is what
+  // tells GA4 to send cookieless pings instead of full hits with cookies.
   window.gtag('consent', 'default', {
     ad_storage: 'denied',
     ad_user_data: 'denied',
@@ -66,14 +98,13 @@ export function initAnalytics() {
     wait_for_update: 500,
   })
 
-  window.gtag('consent', 'update', {
-    analytics_storage: 'granted',
-  })
-
   window.gtag('js', new Date())
   window.gtag('config', GA_ID, {
     anonymize_ip: true,
-    send_page_view: true,
+    // Don't auto-send the initial page view — the gtag config call would
+    // fire it before consent has been read out of localStorage. We send
+    // page_view manually below if the user has previously consented.
+    send_page_view: false,
   })
 
   // Inject the gtag.js script. Async so it doesn't block anything.
@@ -82,7 +113,29 @@ export function initAnalytics() {
   s.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(GA_ID)}`
   document.head.appendChild(s)
 
-  // Flush any track() calls that arrived before init.
+  // If the user already accepted on a previous visit, immediately upgrade
+  // and replay the pending app_view.
+  if (getConsent() === 'granted') {
+    upgradeAnalytics()
+    track('app_view')
+  }
+}
+
+/**
+ * Upgrade from cookieless degraded mode to full analytics collection.
+ * Called from setConsent('granted') (banner accepted) and from
+ * bootGaDegraded when the user has already consented on a previous visit.
+ */
+function upgradeAnalytics() {
+  if (upgraded) return
+  if (!degradedBooted) return
+  upgraded = true
+
+  window.gtag('consent', 'update', {
+    analytics_storage: 'granted',
+  })
+
+  // Now that we have full analytics_storage, flush any pending events.
   for (const [name, params] of pendingEvents) {
     window.gtag('event', name, params)
   }
@@ -91,12 +144,30 @@ export function initAnalytics() {
 
 export function track(eventName, params) {
   if (!IS_WEB || !GA_ID) return
-  if (getConsent() !== 'granted') return
-  if (!initialized) {
+  if (!degradedBooted) return
+
+  // In degraded mode, gtag('event', ...) hits still go out as cookieless
+  // pings if `analytics_storage` is denied — Google's documented behaviour
+  // for Consent Mode v2. Once `update` flips it to granted, the same
+  // events get the full client ID + cookie context.
+  //
+  // We DO still gate on consent for one reason: GA4's "modeled" cookieless
+  // mode is best for high-level page-view signals; named custom events
+  // before consent risks under-measurement and clutter. Buffer named
+  // events until consent and replay on grant.
+  if (!upgraded) {
     pendingEvents.push([eventName, params || {}])
     return
   }
   if (typeof window.gtag === 'function') {
     window.gtag('event', eventName, params || {})
   }
+}
+
+// Backwards-compatible alias — used to be the single init entry point.
+// Kept so existing call sites compile while we transition. New code
+// should call bootGaDegraded() from main.jsx and rely on setConsent.
+export function initAnalytics() {
+  bootGaDegraded()
+  if (getConsent() === 'granted') upgradeAnalytics()
 }

--- a/src/utils/parseBlackbox.js
+++ b/src/utils/parseBlackbox.js
@@ -37,6 +37,58 @@
 import init, { parseBlackbox as wasmParseBlackbox } from 'blackbox-parser'
 import wasmUrl from 'blackbox-parser/blackbox_parser_bg.wasm?url'
 import { mapToViewerLog } from './blackbox-mapper'
+import { captureParseError } from './sentry'
+
+/**
+ * Extract privacy-safe metadata from a blackbox header. We use this to tag
+ * parse-failure reports with enough context to reproduce the issue
+ * (firmware version, schema field names) without ever sending log content.
+ *
+ * Reads only the header lines (those starting with "H "); stops at the
+ * first non-header byte. Header is bounded to the first ~16 KB so this is
+ * cheap even for large files.
+ */
+function extractLogMetadata(bytes) {
+  const HEADER_SCAN_LIMIT = 16 * 1024
+  const limit = Math.min(bytes.length, HEADER_SCAN_LIMIT)
+  let firmware = null
+  let product = null
+  let revision = null
+  let fields = null
+
+  let lineStart = 0
+  for (let i = 0; i < limit; i++) {
+    if (bytes[i] !== 0x0a /* \n */) continue
+    // Line is bytes[lineStart .. i] (excluding \n). First two bytes must
+    // be "H " for it to be a header line.
+    if (i - lineStart < 2 || bytes[lineStart] !== 0x48 || bytes[lineStart + 1] !== 0x20) {
+      // First non-H line — header ended.
+      break
+    }
+    // Decode this header line as ASCII (header is ASCII by spec).
+    let line = ''
+    for (let j = lineStart + 2; j < i; j++) line += String.fromCharCode(bytes[j])
+
+    if (line.startsWith('Product:')) product = line.slice(8).trim()
+    else if (line.startsWith('Firmware:')) firmware = line.slice(9).trim()
+    else if (line.startsWith('Firmware revision:')) revision = line.slice(18).trim()
+    else if (line.startsWith('Field I name:') && !fields) {
+      fields = line
+        .slice(13)
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    }
+    lineStart = i + 1
+  }
+
+  return {
+    product, // e.g. "Blackbox flight data recorder by Nicholas Sherlock"
+    firmware, // e.g. "INAV 9.0.1 (xxx) MATEKF405SE"
+    revision, // e.g. "INAV 9.0.1"
+    fields, // array of field names (column schema)
+  }
+}
 
 /**
  * Translate raw WASM error strings into something a human can act on.
@@ -124,6 +176,11 @@ export async function parseBlackboxBuffer(bytes, filename, onProgress, onDiag) {
   // any future re-attempt) needs a live buffer.
   const bytesForFallback = bytes.slice()
 
+  // Snapshot privacy-safe metadata BEFORE the buffer might get detached.
+  // We use this on parse-failure error reports.
+  const fileSize = bytes.length
+  const meta = extractLogMetadata(bytes)
+
   // Stage 1: spawn the Rust-WASM worker and wait for it to declare ready.
   // If this part fails (timeout, CSP, OOM, …) the worker never received
   // bytes, so it's safe to fall back to the Rust main-thread parser
@@ -139,7 +196,9 @@ export async function parseBlackboxBuffer(bytes, filename, onProgress, onDiag) {
       return await parseOnMainThread(bytes, filename, onProgress, onDiag)
     } catch (mainErr) {
       // Rust main-thread parser also failed. Try the C parser.
-      return await tryCFallback(bytesForFallback, filename, onProgress, onDiag, mainErr)
+      return await tryCFallback(bytesForFallback, filename, onProgress, onDiag, mainErr, {
+        fileSize, meta, parserChain: 'rust-worker-spawn-failed→rust-main→c',
+      })
     }
   }
 
@@ -149,7 +208,9 @@ export async function parseBlackboxBuffer(bytes, filename, onProgress, onDiag) {
   try {
     return await parseViaWorker(worker, bytes, filename, onProgress, onDiag)
   } catch (err) {
-    return await tryCFallback(bytesForFallback, filename, onProgress, onDiag, err)
+    return await tryCFallback(bytesForFallback, filename, onProgress, onDiag, err, {
+      fileSize, meta, parserChain: 'rust-worker→c',
+    })
   }
 }
 
@@ -158,7 +219,7 @@ export async function parseBlackboxBuffer(bytes, filename, onProgress, onDiag) {
  * If it also fails, throw the *original* (Rust) error since that's the
  * one the user is most likely to recognise.
  */
-async function tryCFallback(bytes, filename, onProgress, onDiag, primaryErr) {
+async function tryCFallback(bytes, filename, onProgress, onDiag, primaryErr, ctx) {
   const primaryMsg = primaryErr && primaryErr.message ? primaryErr.message : String(primaryErr)
   if (onDiag) {
     onDiag(`primary parser failed: ${primaryMsg}`)
@@ -171,6 +232,15 @@ async function tryCFallback(bytes, filename, onProgress, onDiag, primaryErr) {
     cFallback = await import('./parseBlackboxC.js')
   } catch (loadErr) {
     if (onDiag) onDiag(`alternate parser bundle failed to load: ${loadErr.message || loadErr}`)
+    // C bundle didn't even load — report the original (Rust) error with
+    // context so we can investigate.
+    captureParseError(primaryErr, {
+      fileSize: ctx?.fileSize,
+      filename: basename(filename),
+      firmware: ctx?.meta?.revision || ctx?.meta?.firmware,
+      fields: ctx?.meta?.fields,
+      parserChain: (ctx?.parserChain || 'rust→c-import-failed'),
+    })
     throw new Error(friendlyErrorMessage(primaryMsg))
   }
 
@@ -180,8 +250,27 @@ async function tryCFallback(bytes, filename, onProgress, onDiag, primaryErr) {
     return log
   } catch (cErr) {
     if (onDiag) onDiag(`alternate parser also failed: ${cErr.message || cErr}`)
+    // Both parsers rejected — this is the interesting case to capture.
+    // We attach the *primary* (Rust) error since that's the more
+    // descriptive enum dump; the C error often just says "no frames".
+    // Also include the C error message in extras for completeness.
+    captureParseError(primaryErr, {
+      fileSize: ctx?.fileSize,
+      filename: basename(filename),
+      firmware: ctx?.meta?.revision || ctx?.meta?.firmware,
+      fields: ctx?.meta?.fields,
+      parserChain: ctx?.parserChain || 'rust→c-both-failed',
+    })
     throw new Error(friendlyErrorMessage(primaryMsg))
   }
+}
+
+// Strip any directory path the browser might have given us. We only ever
+// want the bare filename in the error report.
+function basename(filename) {
+  if (!filename) return null
+  const slash = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'))
+  return slash >= 0 ? filename.slice(slash + 1) : filename
 }
 
 function parseViaWorker(worker, bytes, filename, onProgress, onDiag) {

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,0 +1,169 @@
+/**
+ * Sentry error reporting — privacy-first, consent-aware.
+ *
+ * Boots on every page load (no-op if VITE_SENTRY_DSN is empty), runs in
+ * always-anonymous mode (no PII, no IPs, query strings scrubbed), and
+ * captures unhandled errors plus explicitly-reported parse failures.
+ *
+ * Consent model (Option B — "Consent Mode degraded"):
+ *   - DEFAULT (page load, before consent decision):
+ *       * sendDefaultPii: false
+ *       * IP scrubbed in beforeSend
+ *       * URL query strings stripped (might contain log filenames)
+ *       * Default breadcrumbs DISABLED (no click/console capture) so we
+ *         don't passively record what the user clicked before they
+ *         consented to anything
+ *       * Errors still caught and reported anonymously
+ *   - AFTER `upgradeSentryConsent()`:
+ *       * Breadcrumbs integration added — console + click + fetch breadcrumbs
+ *         ride along with future errors, making them much easier to debug.
+ *       * IP and URL still scrubbed (we never want those).
+ *
+ * Why we still scrub IP/URL on consent grant: the viewer doesn't have user
+ * accounts, so there's nothing on the Sentry side that benefits from
+ * knowing the user's IP. The information would only marginally help (rough
+ * geo) and meaningfully hurt (PII storage). Keep it scrubbed.
+ *
+ * What we never collect:
+ *   - The bytes of any flight log
+ *   - GPS coordinates
+ *   - User-identifiable info (no auth, no email, no UA fingerprint)
+ *
+ * What we DO collect on parse failure (via captureParseError):
+ *   - File size in bytes
+ *   - Firmware product/version string from the log header
+ *   - Frame schema field names (the column list, e.g. "loopIteration,time,axisP")
+ *   - The error message from the parser
+ */
+
+import * as Sentry from '@sentry/react'
+
+const DSN = import.meta.env.VITE_SENTRY_DSN
+const RELEASE = import.meta.env.VITE_RELEASE || 'dev'
+const IS_WEB = import.meta.env.VITE_BUILD_TARGET === 'web'
+
+let initialized = false
+let consentGranted = false
+
+export function isSentryAvailable() {
+  return IS_WEB && !!DSN
+}
+
+/**
+ * Initialise Sentry. Safe to call multiple times — second call is a no-op.
+ * Called from main.jsx before React renders.
+ */
+export function initSentry() {
+  if (initialized) return
+  if (!isSentryAvailable()) return
+
+  initialized = true
+
+  Sentry.init({
+    dsn: DSN,
+    release: RELEASE,
+    environment: import.meta.env.MODE,
+    sendDefaultPii: false,
+
+    // Default integrations include Breadcrumbs which records console logs,
+    // clicks, and fetch — useful for debugging but recorded passively. In
+    // degraded mode (pre-consent) we strip the user-action ones; we re-add
+    // them on consent grant via upgradeSentryConsent().
+    defaultIntegrations: false,
+    integrations: [
+      Sentry.dedupeIntegration(),
+      Sentry.functionToStringIntegration(),
+      Sentry.inboundFiltersIntegration(),
+      // GlobalHandlers catches window.onerror + unhandledrejection — that's
+      // the whole point of having Sentry here, so always on.
+      Sentry.globalHandlersIntegration({ onerror: true, onunhandledrejection: true }),
+      Sentry.linkedErrorsIntegration(),
+      Sentry.httpContextIntegration(),
+    ],
+
+    // No tracing / replay / profiling — those would be high-data features
+    // requiring real consent.
+    tracesSampleRate: 0,
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 0,
+
+    beforeSend(event) {
+      // Always scrub IP — we never want it.
+      if (event.user) {
+        delete event.user.ip_address
+        delete event.user.email
+        delete event.user.id
+      } else {
+        event.user = { ip_address: null }
+      }
+
+      // Strip URL query string — log filenames or share params don't belong
+      // in error reports.
+      if (event.request?.url) {
+        try {
+          const u = new URL(event.request.url)
+          event.request.url = u.origin + u.pathname
+        } catch {
+          // Malformed URL — drop it entirely rather than risk leaking.
+          event.request.url = '[scrubbed]'
+        }
+      }
+
+      return event
+    },
+  })
+}
+
+/**
+ * Upgrade from degraded-anonymous to full-anonymous-with-breadcrumbs.
+ * Called from analytics.js when the user clicks Accept on the consent
+ * banner. We don't unscrub IP or URL — those stay anonymous always.
+ * What changes: breadcrumbs (console / clicks / fetch) start riding along
+ * with future error events so we can see what happened before a crash.
+ */
+export function upgradeSentryConsent() {
+  if (consentGranted) return
+  consentGranted = true
+  if (!initialized) return
+
+  Sentry.addIntegration(Sentry.breadcrumbsIntegration({
+    console: true,
+    dom: true,
+    fetch: true,
+    history: false,
+    sentry: true,
+    xhr: true,
+  }))
+}
+
+/**
+ * Capture a parser failure with privacy-safe context. Called from
+ * parseBlackbox.js after both Rust and C parsers have rejected a file.
+ *
+ * @param {Error} err               The error thrown by the parser
+ * @param {object} ctx              Privacy-safe context only
+ * @param {number} ctx.fileSize     bytes
+ * @param {string} ctx.filename     just the basename + extension, no path
+ * @param {string} [ctx.firmware]   e.g. "Cleanflight", "iNAV 9.0.1"
+ * @param {string[]} [ctx.fields]   frame schema field names (strings only)
+ * @param {string} [ctx.parserChain] which parsers were tried (e.g. "rust→c")
+ */
+export function captureParseError(err, ctx) {
+  if (!initialized) return
+
+  Sentry.captureException(err, {
+    tags: {
+      kind: 'parse_failure',
+      parser_chain: ctx.parserChain || 'unknown',
+    },
+    extra: {
+      file_size_bytes: ctx.fileSize,
+      filename: ctx.filename, // basename only — no path
+      firmware: ctx.firmware,
+      schema_fields: ctx.fields,
+    },
+  })
+}
+
+// Re-export the React Error Boundary so main.jsx can wrap <App />.
+export const SentryErrorBoundary = Sentry.ErrorBoundary

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import cesium from 'vite-plugin-cesium'
 import { VitePWA } from 'vite-plugin-pwa'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // Dual-target build:
 //   VITE_BUILD_TARGET=web      → hosted (Cloudflare Pages, mounted at /log-viewer/
@@ -23,6 +24,18 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 // simple.
 export default defineConfig(() => {
   const isDesktop = process.env.VITE_BUILD_TARGET === 'desktop'
+
+  // Sentry source-map upload. Only runs when an auth token is set (CI /
+  // local with creds in .env.local). Without the token the plugin is
+  // skipped entirely, so dev builds and contributors without Sentry
+  // access still build cleanly. The token must be in the build env
+  // (Cloudflare Pages env vars), not in any committed file.
+  const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
+  const sentryOrg = process.env.SENTRY_ORG
+  const sentryProject = process.env.SENTRY_PROJECT
+  const sentryRelease = process.env.VITE_RELEASE
+  const sentryUploadEnabled =
+    !!sentryAuthToken && !!sentryOrg && !!sentryProject && !isDesktop
 
   const pwa = VitePWA({
     // ⚠️ Self-destroying SW deploy — flushes a stale SW that was caching
@@ -100,7 +113,31 @@ export default defineConfig(() => {
     // wasm + topLevelAwait teach Vite/Rollup to handle the ESM-style WASM
     // import that `wasm-pack build --target bundler` emits — needed by
     // `@narenana/blackbox-parser`. Order matters: wasm before topLevelAwait.
-    plugins: [react(), wasm(), topLevelAwait(), cesium(), ...(isDesktop ? [] : [pwa])],
+    // sentryVitePlugin must come LAST so it sees the final emitted bundle
+    // for source-map upload + release tagging.
+    plugins: [
+      react(),
+      wasm(),
+      topLevelAwait(),
+      cesium(),
+      ...(isDesktop ? [] : [pwa]),
+      ...(sentryUploadEnabled
+        ? [
+            sentryVitePlugin({
+              authToken: sentryAuthToken,
+              org: sentryOrg,
+              project: sentryProject,
+              release: sentryRelease ? { name: sentryRelease } : undefined,
+              telemetry: false,
+              // Plugin's default sourcemaps config uploads dist/**/*.map
+              // and then deletes them so they don't ship to users. Good.
+            }),
+          ]
+        : []),
+    ],
+    // Generate source maps so the Sentry plugin has something to upload.
+    // Without this, stack traces in the Sentry UI stay minified.
+    build: { outDir: 'dist', sourcemap: sentryUploadEnabled ? 'hidden' : false },
     // Vite worker contexts use a separate plugin pipeline. The blackbox
     // parser worker needs the same WASM glue, so re-register both
     // plugins here. Without this the worker build fails with the
@@ -125,6 +162,5 @@ export default defineConfig(() => {
         }
       : {},
     server: { port: 5173, strictPort: true, hmr: { port: 5173 } },
-    build: { outDir: 'dist' },
   }
 })


### PR DESCRIPTION
## Summary

- Wire **Sentry SaaS** (\`@sentry/react\` v10.51) for crash reporting in always-anonymous mode (no PII, IP scrubbed, URL query strings stripped). Default integrations disabled until consent is granted, then breadcrumbs (clicks/console) flip on so post-Accept crashes carry context.
- Upgrade **GA4** from strict opt-in to **Consent Mode v2 cookieless pings** on every page load — anonymous aggregate hits, no \`_ga\` cookie. Same Accept button on the existing consent banner upgrades both tools to fuller collection. Decline = stay in always-anonymous mode (no banner re-prompt).
- Privacy-safe **parser failure capture** in \`parseBlackbox.js\` — when both Rust and C parsers reject a file, sends file size, basename only (no path), firmware revision string, frame schema field names, parser chain. Never log content.

## Consent model — what users see

|                              | Default (page load) | After Accept | After Decline |
|------------------------------|---------------------|--------------|---------------|
| Crash reports (anonymous)    | ✓                   | ✓            | ✓             |
| IP / URL query / PII         | scrubbed            | scrubbed     | scrubbed      |
| Click/console breadcrumbs    | not collected       | collected    | not collected |
| GA4 \`_ga\` cookie             | not set             | set          | not set       |
| GA4 cookieless pings         | sent                | upgraded     | continue      |

Full disclosure in [\`SENTRY.md\`](SENTRY.md), linked from README.

## Test plan

- [x] Web build clean with empty \`VITE_SENTRY_DSN\` (Vite tree-shakes Sentry → bundle 326 KB / gzip 82 KB, +0 vs master)
- [x] Web build clean with DSN set (Sentry active → bundle 431 KB / gzip 110 KB, +28 KB gzip — the actual @sentry/react weight)
- [x] Desktop build clean — Sentry bundled but \`IS_WEB\` guard makes it a runtime no-op
- [x] DSN string verified baked into \`dist/assets/index-*.js\` after build
- [ ] **Reviewer (Naren)**: set \`VITE_SENTRY_DSN\` in Cloudflare Pages env vars (Production + Preview); branch preview at \`latest.narenana.com\` after env var is set
- [ ] **Reviewer**: trigger a test error from browser console (\`throw new Error('test')\` inside an event handler) and verify it lands in the Sentry inbox
- [ ] **Reviewer**: optionally set \`SENTRY_AUTH_TOKEN\` + \`SENTRY_ORG\` + \`SENTRY_PROJECT\` for source-map upload (recommended; without these, stack traces stay minified)
- [ ] **Reviewer**: load a known-good iNAV log + a known-bad one (LOG00007 = the early-boot iNAV 9 partial-parse case from PR #20); verify good logs don't trigger captures and the bad log only triggers if BOTH parsers fail

## Build env vars

| Var | Where | Required? | Purpose |
|---|---|---|---|
| \`VITE_SENTRY_DSN\` | Cloudflare Pages | yes (else no-op) | Sentry endpoint, baked into client bundle |
| \`VITE_RELEASE\` | Cloudflare Pages | recommended | Tag events with commit SHA. Set to \`\$CF_PAGES_COMMIT_SHA\` |
| \`SENTRY_AUTH_TOKEN\` | Cloudflare Pages (build only) | recommended | Source-map upload via @sentry/vite-plugin |
| \`SENTRY_ORG\` | Cloudflare Pages (build only) | with token | Org slug |
| \`SENTRY_PROJECT\` | Cloudflare Pages (build only) | with token | Project slug |

## Rollback

Set \`VITE_SENTRY_DSN\` empty in Cloudflare Pages and rebuild — Vite tree-shakes Sentry out entirely. Bundle size returns to master baseline. Or revert this commit; the consent banner gracefully degrades since \`isSentryAvailable()\` controls whether the banner mentions crash reports.

## Future work (not in this PR)

- Dynamic-import \`@sentry/react\` on desktop builds to drop the 100 KB no-op weight
- Set up Sentry alerts for parse-failure tag (\`kind=parse_failure\`) so iNAV writer regressions surface fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)