### PR TITLE
Fix iNAV pitch sign + dominant-mode mapping

### DIFF
--- a/src/utils/blackbox-mapper.js
+++ b/src/utils/blackbox-mapper.js
@@ -340,20 +340,46 @@ function haversineKm(lat1, lon1, lat2, lon2) {
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
 }
 
-const NAV_STATES = [
-  'IDLE',
-  'ALT_HOLD',
-  'POS_HOLD',
-  'RTH',
-  'WP',
-  'EMERG_LANDING',
-  'LAUNCH',
-  'CRUISE',
-  'COURSE_HOLD',
-  'MIXER_TRANSITION',
-]
+// iNAV's `NAV_PERSISTENT_ID_*` table from src/main/navigation/navigation_private.h.
+// These IDs are explicitly stable across iNAV firmware versions — the
+// underlying `navigationFSMState_t` enum is allowed to renumber, but
+// blackbox writes the persistent ID so external tools have a fixed
+// reference. Each major mode owns 1–7 sequential IDs (one per state-
+// machine slot: INITIALIZE / IN_PROGRESS / ADJUSTING / FINISHING / …);
+// we collapse them to the user-facing mode name.
+//
+// Important: ID 1 (`NAV_PERSISTENT_ID_IDLE`) means the navigation state
+// machine is OFF — the pilot is flying with sticks (ACRO / ANGLE /
+// HORIZON / MANUAL). Without the `flightModeFlags` slow-frame field
+// (not always logged) we can't tell which manual mode was active, so
+// we label these rows "MANUAL". The previous version of this table
+// indexed by the live `navigationFSMState_t` enum — which made id 1
+// resolve to "ALT_HOLD" instead of IDLE, so any flight where the FSM
+// stayed idle (i.e. anyone flying without nav-mode autopilot engaged)
+// reported ALT_HOLD as the dominant mode.
+const NAV_PERSISTENT_LABELS = {
+  0: '',                                             // UNDEFINED
+  1: 'MANUAL',                                       // IDLE — sticks-only flying
+  2: 'ALT_HOLD', 3: 'ALT_HOLD',
+  // 4, 5: unused (was POSHOLD_2D — removed from iNAV)
+  6: 'POS_HOLD', 7: 'POS_HOLD',
+  8: 'RTH', 9: 'RTH', 10: 'RTH', 11: 'RTH', 12: 'RTH', 13: 'RTH', 14: 'RTH',
+  15: 'WP', 16: 'WP', 17: 'WP', 18: 'WP', 19: 'WP', 20: 'WP', 21: 'WP',
+  22: 'EMERG_LANDING', 23: 'EMERG_LANDING', 24: 'EMERG_LANDING',
+  25: 'LAUNCH', 26: 'LAUNCH', 28: 'LAUNCH',          // 27 unused
+  29: 'COURSE_HOLD', 30: 'COURSE_HOLD', 31: 'COURSE_HOLD',
+  32: 'CRUISE', 33: 'CRUISE', 34: 'CRUISE',
+  35: 'WP',                                          // WAYPOINT_HOLD_TIME
+  36: 'RTH',                                         // RTH_LOITER_ABOVE_HOME
+  // 37: unused (was WP_HOVER_ABOVE_HOME)
+  38: 'RTH',                                         // RTH_TRACKBACK
+  39: 'MIXER_TRANSITION', 40: 'MIXER_TRANSITION', 41: 'MIXER_TRANSITION',
+  42: 'FW_LANDING', 43: 'FW_LANDING', 44: 'FW_LANDING', 45: 'FW_LANDING',
+  46: 'FW_LANDING', 47: 'FW_LANDING', 48: 'FW_LANDING',
+  49: 'SEND_TO', 50: 'SEND_TO', 51: 'SEND_TO',
+}
 function navStateLabel(v) {
   if (v == null) return ''
   const i = Math.round(v)
-  return NAV_STATES[i] != null ? NAV_STATES[i] : `FM${i}`
+  return NAV_PERSISTENT_LABELS[i] ?? `FM${i}`
 }

--- a/src/utils/blackbox-mapper.js
+++ b/src/utils/blackbox-mapper.js
@@ -214,7 +214,14 @@ export function mapToViewerLog(parsed, filename, diag = () => {}) {
       'Ptch(rad)': pitchDeg != null ? (pitchDeg * Math.PI) / 180 : null,
       'Roll(rad)': rollDeg != null ? (rollDeg * Math.PI) / 180 : null,
       'Yaw(rad)': yawDeg != null ? (yawDeg * Math.PI) / 180 : null,
-      _pitchDeg: pitchDeg,
+      // iNAV's `attitude.values.pitch` (MSP_ATTITUDE convention) is
+      // POSITIVE when the nose is DOWN. We invert here so `_pitchDeg`
+      // follows the aviation convention POSITIVE = nose-up (climb)
+      // throughout the app — what the AI gauge, pitch chart, and any
+      // future consumer naturally expect. The raw `Ptch(rad)` field
+      // above is left as-is so anyone exporting back to an EdgeTX-style
+      // CSV preserves the source convention.
+      _pitchDeg: pitchDeg != null ? -pitchDeg : null,
       _rollDeg: rollDeg,
       _yawDeg: yawDeg,
       'RxBt(V)': vbat,

--- a/src/utils/parseLog.js
+++ b/src/utils/parseLog.js
@@ -84,7 +84,12 @@ export function parseEdgeTXLog(text, filename) {
       _tSec: (ts - t0) / 1000,
       _lat: lat,
       _lon: lon,
-      _pitchDeg: r['Ptch(rad)'] != null ? r['Ptch(rad)'] * R2D : null,
+      // iNAV / Betaflight FCs both telemeter pitch as POSITIVE = nose-down
+      // (matches MSP_ATTITUDE). Invert here so `_pitchDeg` follows the
+      // aviation convention (+ve = nose-up = climb) the rest of the app
+      // — AI gauge, pitch chart, etc. — naturally expects. Raw `Ptch(rad)`
+      // on the row is left untouched.
+      _pitchDeg: r['Ptch(rad)'] != null ? -r['Ptch(rad)'] * R2D : null,
       _rollDeg: r['Roll(rad)'] != null ? r['Roll(rad)'] * R2D : null,
       _yawDeg: r['Yaw(rad)'] != null ? r['Yaw(rad)'] * R2D : null,
       'Hdg(°)': normHdg(r['Hdg(°)']),


### PR DESCRIPTION
## Summary

Two related iNAV-correctness fixes that surfaced from a single user log (LOG00003) where the flight had no nav-mode autopilot engaged at all.

### 1. Dominant mode reported as ALT_HOLD even when alt-hold was never armed

`navStateLabel()` indexed a 10-element \`NAV_STATES\` array directly with the raw blackbox \`navState\` value. iNAV's underlying \`navigationFSMState_t\` is a state machine where each major mode owns 1–7 sequential slots (INITIALIZE / IN_PROGRESS / ADJUSTING / FINISHING / …) — so the array's "ALT_HOLD" landed at index 1, which actually corresponds to \`NAV_PERSISTENT_ID_IDLE\`. Any flight where the navigation FSM stayed idle (anyone flying manually) streamed id=1 every row → "ALT_HOLD" in the summary.

Replaced with a \`NAV_PERSISTENT_ID_*\` lookup table from iNAV's \`src/main/navigation/navigation_private.h\`. The persistent IDs are explicitly stable across iNAV firmware versions for exactly this reason — external tools shouldn't depend on the live enum.

Limitation noted in the code: id 1 (IDLE) covers all sticks-only modes (ACRO / ANGLE / HORIZON / MANUAL); without the \`flightModeFlags\` slow-frame field (not always logged) we can't tell which manual mode was active, so they all label as "MANUAL". Improving that needs slow-frame parsing — left as a follow-up.

### 2. Artificial-horizon pitch was inverted

iNAV's \`attitude.values.pitch\` (and the matching FrSky/MSP_ATTITUDE telemetry that EdgeTX records) is **positive when the nose is down**. Both the AI gauge and the pitch chart in Dashboard treat their input as aviation convention (+ve = nose-up = climb), so the displays read inverted on every iNAV/Betaflight log. Fixed at the parser level so \`_pitchDeg\` follows aviation convention everywhere downstream — both \`blackbox-mapper.js\` and \`parseLog.js\`. Raw \`Ptch(rad)\` row field is left as the source value so a CSV re-export still matches EdgeTX semantics. Roll convention already matched between iNAV and aviation; no change there.

## Test plan

- [x] User confirmed dominant-mode and AI pitch both look right against \`LOG00003 (2).TXT\` on staging.
- [x] Sample fixed-wing log still loads (no other consumer of \`_pitchDeg\` lost in the sign change — verified by code grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)