### PR TITLE
feat(seo): viewer metadata — canonical, SoftwareApplication JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0e1117" />
 
-    <title>RC Log Viewer — replay every flight in 3D</title>
+    <title>RC Log Viewer — replay EdgeTX & iNAV / Betaflight flight logs in 3D</title>
     <meta name="description" content="Drop EdgeTX CSV or iNAV / Betaflight blackbox logs and replay the entire flight on a 3D globe with synced charts. Works in the browser — your logs never leave your machine." />
+    <meta name="author" content="narenana" />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
+
+    <!-- Canonical URL. The user-facing URL is on the www host; the
+         CF Pages preview/branch hostnames should not be the canonical
+         entry in search results. -->
+    <link rel="canonical" href="https://www.narenana.com/log-viewer/" />
 
     <!-- Brand mark from the narenana YouTube channel — used by every shell:
          browser tab favicon, iOS apple-touch-icon, and the PWA manifest icon.
@@ -20,10 +27,12 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="narenana" />
-    <meta property="og:url" content="https://narenana.com/log-viewer/" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:url" content="https://www.narenana.com/log-viewer/" />
     <meta property="og:title" content="RC Log Viewer — replay every flight in 3D" />
     <meta property="og:description" content="Drop EdgeTX CSV or iNAV / Betaflight blackbox logs. Replay your flight in 3D with synced telemetry charts. Browser-native — your logs never leave your machine." />
     <meta property="og:image" content="https://img.youtube.com/vi/6MLQCoG5t2w/maxresdefault.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="720" />
     <meta property="og:image:alt" content="RC Log Viewer — 3D flight replay on a satellite globe with synced telemetry charts" />
@@ -34,6 +43,46 @@
     <meta name="twitter:description" content="Drop EdgeTX CSV or iNAV / Betaflight blackbox. Replay every flight in 3D with synced telemetry charts. Browser-native, nothing uploaded." />
     <meta name="twitter:image" content="https://img.youtube.com/vi/6MLQCoG5t2w/maxresdefault.jpg" />
     <meta name="twitter:image:alt" content="RC Log Viewer — 3D flight replay" />
+
+    <!-- Schema.org SoftwareApplication. Makes the tool eligible for
+         Google's product / app-card rich results and gives Google
+         Search a concrete entity to associate with queries like
+         "iNAV blackbox viewer" or "EdgeTX log viewer browser".
+         price:0 is required for free apps under the SoftwareApplication
+         spec; omitting it disqualifies the card. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "RC Log Viewer",
+        "alternateName": ["narenana RC Log Viewer", "EdgeTX Log Viewer", "iNAV Blackbox Viewer"],
+        "url": "https://www.narenana.com/log-viewer/",
+        "applicationCategory": "UtilitiesApplication",
+        "applicationSubCategory": "Flight log analysis",
+        "operatingSystem": "Web Browser, Windows, macOS, Linux",
+        "browserRequirements": "Requires WebGL 2 and ES2022. Chrome 100+, Firefox 100+, Safari 16+.",
+        "description": "Drop EdgeTX CSV or iNAV / Betaflight blackbox logs and replay the entire flight on a 3D globe with synced telemetry charts. Runs entirely in the browser; nothing uploaded. Also ships as a desktop app for Windows, macOS, and Linux.",
+        "image": "https://img.youtube.com/vi/6MLQCoG5t2w/maxresdefault.jpg",
+        "screenshot": "https://img.youtube.com/vi/6MLQCoG5t2w/maxresdefault.jpg",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "softwareVersion": "5.0.0",
+        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+        "author": {
+          "@type": "Organization",
+          "name": "narenana",
+          "url": "https://www.narenana.com/"
+        },
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "narenana",
+          "url": "https://www.narenana.com/"
+        }
+      }
+    </script>
   </head>
   <body>
     <!-- Apply the saved theme BEFORE React mounts so there's no flash of


### PR DESCRIPTION
## Summary

Phase 1b of the SEO push — viewer-side metadata. Companion to https://github.com/narenana/narenana-website/pull/new/feat/seo-foundation which does the landing-page side.

- **Canonical URL** → `https://www.narenana.com/log-viewer/`. CF Pages preview hostnames and the apex variant no longer compete with the canonical www URL in search results.
- **SoftwareApplication JSON-LD** — gives the viewer its own indexed entity so it can rank on its own merits for queries like "iNAV blackbox viewer" or "EdgeTX log viewer browser" without competing with the brand landing.
  - `alternateName`: ["narenana RC Log Viewer", "EdgeTX Log Viewer", "iNAV Blackbox Viewer"]
  - `browserRequirements`: WebGL 2 + ES2022
  - `offers.price`: "0" (required for free apps; omitting disqualifies the rich result)
  - `isPartOf`: shared WebSite URL with the landing's JSON-LD, so Google can stitch the entities together.
- **og:locale, og:image:type, robots, author meta** — small share-card / crawler wins.
- **Title** bumped to include format keywords ("EdgeTX & iNAV / Betaflight").

Note: `softwareVersion` is hardcoded to `5.0.0` (matches `package.json`). Update on each release. Could switch to a Vite-plugin-html template if it drifts.

## Test plan

- [ ] Build + verify JSON-LD survives Vite output. (Confirmed locally — 3 grep matches in `dist/index.html`.)
- [ ] After deploy, run the URL through https://search.google.com/test/rich-results — SoftwareApplication should validate.
- [ ] Verify canonical resolves correctly (no canonical-loop with the apex redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)