### PR TITLE
chore: gate parser console.logs on DEV + re-enable PWA

### DIFF
--- a/src/utils/parseBlackbox.js
+++ b/src/utils/parseBlackbox.js
@@ -313,7 +313,10 @@ async function parseOnMainThread(bytes, filename, onProgress, onDiag) {
   const diag = msg => {
     const line = `+${(performance.now() - t0).toFixed(0)}ms ${msg} (main-thread fallback)`
     if (onDiag) onDiag(line)
-    console.log('[bb-parse]', line)
+    // The onDiag callback is the production channel (surfaces to the UI
+    // / Sentry breadcrumbs). The console.log is dev-only — Vite strips
+    // it from prod builds via the `import.meta.env.DEV` constant fold.
+    if (import.meta.env.DEV) console.log('[bb-parse]', line)
   }
 
   diag(`received ${filename} (${bytes.length.toLocaleString()} bytes)`)

--- a/src/utils/parseBlackboxC.js
+++ b/src/utils/parseBlackboxC.js
@@ -52,7 +52,10 @@ export async function parseBlackboxBufferC(bytes, filename, onProgress, onDiag) 
   const diag = msg => {
     const line = `+${(performance.now() - t0).toFixed(0)}ms ${msg} (C parser)`
     if (onDiag) onDiag(line)
-    if (typeof console !== 'undefined') console.log('[bb-parse-c]', line)
+    // The onDiag callback is the production channel (surfaces to the UI
+    // / Sentry breadcrumbs). The console.log is dev-only — Vite strips
+    // it from prod builds via the `import.meta.env.DEV` constant fold.
+    if (import.meta.env.DEV && typeof console !== 'undefined') console.log('[bb-parse-c]', line)
   }
 
   diag(`received ${filename} (${bytes.length.toLocaleString()} bytes)`)

--- a/vite.config.js
+++ b/vite.config.js
@@ -38,13 +38,15 @@ export default defineConfig(() => {
     !!sentryAuthToken && !!sentryOrg && !!sentryProject && !isDesktop
 
   const pwa = VitePWA({
-    // ⚠️ Self-destroying SW deploy — flushes a stale SW that was caching
-    // landing-page HTML at /log-viewer/index.html (caused by a Worker bug
-    // where Pages' 308 `Location: /` redirect leaked past the prefix).
-    // The Worker bug is fixed in narenana-website. After verifying users
-    // recover, flip `selfDestroying` back to false in a follow-up deploy
-    // to re-enable the PWA.
-    selfDestroying: true,
+    // Re-enabled after the self-destroying flush deploy ran for ~2 weeks.
+    // History: a Worker bug (Pages' 308 `Location: /` redirect leaked past
+    // the `/log-viewer/` prefix) caused the SW to cache the landing page
+    // HTML under the viewer's precache key. The Worker fix shipped in
+    // narenana-website, then this config ran with `selfDestroying: true`
+    // long enough that any user who'd loaded the viewer during the bug
+    // window would have flushed the bad SW. PWA install + offline now
+    // work again.
+    selfDestroying: false,
     registerType: 'autoUpdate',
     injectRegister: 'auto',
     devOptions: { enabled: false },


### PR DESCRIPTION
## Summary

Two small post-merge cleanups surfaced in the code-review pass.

### 1. Gate parser console.logs on `import.meta.env.DEV`

`parseBlackbox.js:316` and `parseBlackboxC.js:55` were unconditionally emitting `[bb-parse]` / `[bb-parse-c]` console.log lines for every parse step (10+ lines per blackbox load). The `onDiag` callback is the production channel — it surfaces to the UI and to Sentry breadcrumbs. The console.log was branch-leftover debug.

Gated on `import.meta.env.DEV` so Vite strips the calls from production bundles via constant-folding + dead-code elimination. **Verified: 0 matches in the built JS.**

### 2. Re-enable PWA (`selfDestroying: false`)

`vite.config.js:47` was `selfDestroying: true` — the flush-fix for the stale-SW bug after the Worker `/log-viewer/` redirect issue (PR for that landed in narenana-website ~2 weeks ago). The flush window is long past — any user who'd loaded the viewer during the bug window would have re-visited and flushed the bad SW by now.

Flipped back to `false` to re-enable install + offline. **Verified: `dist/sw.js` is now generated by the build.**

## Also done (not in this PR)

- Deleted 9 stale remote branches that were already squash-merged: `feat/flight-path-tube`, `feat/fly-away-detection`, `feat/inav9-support`, `feat/path-following-aircraft`, `feat/playback-bookmarks`, `fix/sticky-bottom-bar`, `feat/error-logging`, `feature/blackbox-parser`, `feature/radio-stick-animation`. Remote now has only `master`, this PR, and the in-flight `feat/seo-viewer-metadata`.

## Test plan

- [x] Build succeeds.
- [x] `bb-parse` strings absent from production JS bundles.
- [x] `dist/sw.js` generated (PWA re-enabled).
- [ ] After deploy, install the app on Chrome desktop / mobile — should work.
- [ ] Offline reload — viewer should still load from SW cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)